### PR TITLE
Updated checklist analytics and disabled some tabs

### DIFF
--- a/src/apps/Commissioning/index.tsx
+++ b/src/apps/Commissioning/index.tsx
@@ -80,91 +80,91 @@ const analyticsOptions2: AnalyticsOptions<WP> = {
 
 export function setup(appApi: AppApi): void {
     const api = baseClient(appApi.authProvider, [appApi.appConfig.procosys]);
-    const construction = createPageViewer({
+    const commissioning = createPageViewer({
         viewerId: appApi.shortName,
         title: appApi.title,
     });
 
-    /** 
-    Remove SWCR analytics, since its not relevant for Construction
-    */
+    commissioning.registerFusionPowerBi('swcr-analytics-rls', {
+        title: 'SWCR Analytics',
+        reportURI: 'swcr-analytics-rls',
+    });
 
-    // construction.registerFusionPowerBi('swcr-analytics-rls', {
-    //     title: 'SWCR Analytics',
-    //     reportURI: 'swcr-analytics-rls',
+    // const workPreparation = commissioning.registerDashboard<WP>('work-preparation', {
+    //     title: 'Work Preparation',
     // });
 
-    const workPreparation = construction.registerDashboard<WP>('work-preparation', {
-        title: 'Work Preparation',
-    });
+    // // Loop Data Test for testing system..
+    // workPreparation.registerDataSource(async () => {
+    //     const plantId = 'PCS$JOHAN_CASTBERG';
+    //     const project = 'L.O532C.002';
+    //     const response = await api.fetch(
+    //         `https://api-lighthouse-production.playground.radix.equinor.com/loops/${plantId}/${project}`
+    //     );
 
-    // Loop Data Test for testing system..
-    workPreparation.registerDataSource(async () => {
-        const plantId = 'PCS$JOHAN_CASTBERG';
-        const project = 'L.O532C.002';
-        const response = await api.fetch(
-            `https://api-lighthouse-production.playground.radix.equinor.com/loops/${plantId}/${project}`
-        );
+    //     return JSON.parse(await response.text());
+    // });
 
-        return JSON.parse(await response.text());
-    });
+    // const excludeKeys: (keyof WP)[] = [
+    //     'tagNo',
+    //     'functionTags',
+    //     'contentChecklists',
+    //     'description',
+    //     'commPk',
+    //     'mcPk',
+    //     'signedAt',
+    //     'createdAt',
+    // ];
 
-    const excludeKeys: (keyof WP)[] = [
-        'tagNo',
-        'functionTags',
-        'contentChecklists',
-        'description',
-        'commPk',
-        'mcPk',
-        'signedAt',
-        'createdAt',
-    ];
+    // workPreparation.registerFilterOptions({ excludeKeys });
 
-    workPreparation.registerFilterOptions({ excludeKeys });
+    // workPreparation.registerPage({
+    //     title: 'Jobcards',
+    //     pageId: 'workPreparationJobCards',
+    //     type: 'AnalyticsPage',
+    //     ...analyticsOptions,
+    // });
 
-    workPreparation.registerPage({
-        title: 'Jobcards',
-        pageId: 'workPreparationJobCards',
-        type: 'AnalyticsPage',
-        ...analyticsOptions,
-    });
-
-    workPreparation.registerPage({
-        title: 'Hours',
-        pageId: 'workPreparationHours',
-        type: 'AnalyticsPage',
-        ...analyticsOptions2,
-    });
-    workPreparation.registerPage({
-        title: 'Details',
-        pageId: 'workPreparationDetails',
-        type: 'AnalyticsPage',
-        ...analyticsOptions,
-    });
-    workPreparation.registerPage({
-        title: 'Hold',
-        pageId: 'workPreparationDetailsHold',
-        type: 'AnalyticsPage',
-        ...analyticsOptions2,
-    });
+    // workPreparation.registerPage({
+    //     title: 'Hours',
+    //     pageId: 'workPreparationHours',
+    //     type: 'AnalyticsPage',
+    //     ...analyticsOptions2,
+    // });
+    // workPreparation.registerPage({
+    //     title: 'Details',
+    //     pageId: 'workPreparationDetails',
+    //     type: 'AnalyticsPage',
+    //     ...analyticsOptions,
+    // });
+    // workPreparation.registerPage({
+    //     title: 'Hold',
+    //     pageId: 'workPreparationDetailsHold',
+    //     type: 'AnalyticsPage',
+    //     ...analyticsOptions2,
+    // });
 
     /** 
-    Remove LCI hanging garden, since its not relevant for Construction
+    Remove LCI hanging garden, since its not relevant for Commissioning
     */
     // construction.registerFusionPowerBi('lci-hanging-gardens', {
     //     title: 'LCI Hanging Garden',
     //     reportURI: 'lci-hanging-gardens',
     // });
-    construction.registerFusionPowerBi('jca-checklist', {
+    commissioning.registerFusionPowerBi('jca-checklist', {
         title: 'Checklist Analytics',
         reportURI: 'jca-checklist',
     });
-    construction.registerFusionPowerBi('ec2496e8-e440-441c-8e20-73d3a9d56f74', {
+    commissioning.registerFusionPowerBi('ec2496e8-e440-441c-8e20-73d3a9d56f74', {
         title: 'Punch Analytics',
         reportURI: 'punch-analytics-rls',
     });
-    construction.registerFusionPowerBi('fd4052a9-641b-47b4-92d6-4876ecb8cdba', {
-        title: 'WO Analytics',
-        reportURI: 'wo-analytics-rls',
-    });
+
+    /** 
+    Remove LCI hanging garden, since its not relevant for Commissioning
+    */
+    // construction.registerFusionPowerBi('fd4052a9-641b-47b4-92d6-4876ecb8cdba', {
+    //     title: 'WO Analytics',
+    //     reportURI: 'wo-analytics-rls',
+    // });
 }

--- a/src/apps/Construction/index.tsx
+++ b/src/apps/Construction/index.tsx
@@ -94,59 +94,59 @@ export function setup(appApi: AppApi): void {
     //     reportURI: 'swcr-analytics-rls',
     // });
 
-    const workPreparation = construction.registerDashboard<WP>('work-preparation', {
-        title: 'Work Preparation',
-    });
+    // const workPreparation = construction.registerDashboard<WP>('work-preparation', {
+    //     title: 'Work Preparation',
+    // });
 
-    // Loop Data Test for testing system..
-    workPreparation.registerDataSource(async () => {
-        const plantId = 'PCS$JOHAN_CASTBERG';
-        const project = 'L.O532C.002';
-        const response = await api.fetch(
-            `https://api-lighthouse-production.playground.radix.equinor.com/loops/${plantId}/${project}`
-        );
+    // // Loop Data Test for testing system..
+    // workPreparation.registerDataSource(async () => {
+    //     const plantId = 'PCS$JOHAN_CASTBERG';
+    //     const project = 'L.O532C.002';
+    //     const response = await api.fetch(
+    //         `https://api-lighthouse-production.playground.radix.equinor.com/loops/${plantId}/${project}`
+    //     );
 
-        return JSON.parse(await response.text());
-    });
+    //     return JSON.parse(await response.text());
+    // });
 
-    const excludeKeys: (keyof WP)[] = [
-        'tagNo',
-        'functionTags',
-        'contentChecklists',
-        'description',
-        'commPk',
-        'mcPk',
-        'signedAt',
-        'createdAt',
-    ];
+    // const excludeKeys: (keyof WP)[] = [
+    //     'tagNo',
+    //     'functionTags',
+    //     'contentChecklists',
+    //     'description',
+    //     'commPk',
+    //     'mcPk',
+    //     'signedAt',
+    //     'createdAt',
+    // ];
 
-    workPreparation.registerFilterOptions({ excludeKeys });
+    // workPreparation.registerFilterOptions({ excludeKeys });
 
-    workPreparation.registerPage({
-        title: 'Jobcards',
-        pageId: 'workPreparationJobCards',
-        type: 'AnalyticsPage',
-        ...analyticsOptions,
-    });
+    // workPreparation.registerPage({
+    //     title: 'Jobcards',
+    //     pageId: 'workPreparationJobCards',
+    //     type: 'AnalyticsPage',
+    //     ...analyticsOptions,
+    // });
 
-    workPreparation.registerPage({
-        title: 'Hours',
-        pageId: 'workPreparationHours',
-        type: 'AnalyticsPage',
-        ...analyticsOptions2,
-    });
-    workPreparation.registerPage({
-        title: 'Details',
-        pageId: 'workPreparationDetails',
-        type: 'AnalyticsPage',
-        ...analyticsOptions,
-    });
-    workPreparation.registerPage({
-        title: 'Hold',
-        pageId: 'workPreparationDetailsHold',
-        type: 'AnalyticsPage',
-        ...analyticsOptions2,
-    });
+    // workPreparation.registerPage({
+    //     title: 'Hours',
+    //     pageId: 'workPreparationHours',
+    //     type: 'AnalyticsPage',
+    //     ...analyticsOptions2,
+    // });
+    // workPreparation.registerPage({
+    //     title: 'Details',
+    //     pageId: 'workPreparationDetails',
+    //     type: 'AnalyticsPage',
+    //     ...analyticsOptions,
+    // });
+    // workPreparation.registerPage({
+    //     title: 'Hold',
+    //     pageId: 'workPreparationDetailsHold',
+    //     type: 'AnalyticsPage',
+    //     ...analyticsOptions2,
+    // });
 
     /** 
     Remove LCI hanging garden, since its not relevant for Construction

--- a/src/apps/apps.ts
+++ b/src/apps/apps.ts
@@ -19,6 +19,7 @@ import { SSUIcon } from '../icons/SSUIcon';
 import { ModelViewer } from './3DModel/src/3DModel';
 import { setup as checklistSetup } from './checklistApp';
 import { setup as constructionSetup } from './Construction';
+import { setup as commissioningSetup } from './Commissioning';
 import { setup as handoverSetup } from './handoverApp';
 import { setup as scopeChangeSetup } from './ScopeChangeRequest/ScopeChangeRequestApp';
 import { setup as loopSetup } from './Loop/loopApp';
@@ -250,7 +251,7 @@ export const apps: AppManifest[] = [
         tags: [],
         app: {
             appType: 'PageView',
-            setup: constructionSetup,
+            setup: commissioningSetup,
             component: PageView,
         },
     },


### PR DESCRIPTION
# Description
Updated the checklist analytics PBI report to use a report specific for JCA
Disabled some tabs for construction and commissioning app
Removed tabs are shown below

Construction 
1. SWCR analytics
2. LCI hanging garden

Comissioning
1. Work prep
2. LCI hanging
3. WO analytics


Completes: AB#FILL_IN_YOUR_ISSUE_ID

## Checklist:

-   [x] I have performed a self-review of my own code.
-   [ ] I have linked my DevOps task using the AB# tag.
-   [ ] My code is easy to read, and comments are added where needed.
-   [ ] My code is covered by tests.
