### PR TITLE
fix: add scrollbar when overflow in sidesheet

### DIFF
--- a/src/packages/Sidesheet/Components/PopoutSidesheet.tsx
+++ b/src/packages/Sidesheet/Components/PopoutSidesheet.tsx
@@ -27,4 +27,5 @@ const Wrapper = styled.div`
     height: 100%;
     background: white;
     border-left: 2px solid ${tokens.colors.ui.background__medium.rgba};
+    overflow: scroll;
 `;


### PR DESCRIPTION
# Description

When Sidesheet content is overflowing, add scrollbar to the sidesheet component wrapper.


## Checklist:

-   [ ] I have performed a self-review of my own code.
-   [ ] I have linked my DevOps task using the AB# tag.
-   [ ] My code is easy to read, and comments are added where needed.
-   [ ] My code is covered by tests.
