### PR TITLE
[Table] - fix: DateCell component handles empty string value

### DIFF
--- a/src/packages/Table/Components/Cells/DateCell.tsx
+++ b/src/packages/Table/Components/Cells/DateCell.tsx
@@ -11,5 +11,9 @@ export const DateCell = <T extends TableData>(props: CellProps<T, CellRenderProp
         () => (cellAttributeFn ? cellAttributeFn(content) : undefined),
         [cellAttributeFn]
     );
-    return <div {...attr}>{new Date(content[currentKey] as Date).toLocaleDateString()}</div>;
+
+    const dateDisplay = content[currentKey]
+        ? new Date(content[currentKey] as string).toLocaleDateString()
+        : '';
+    return <div {...attr}>{dateDisplay}</div>;
 };


### PR DESCRIPTION
# Description

DateCell component would show 1970 or something if string was empty. Will now show an empty string if the string passed to the component is empty.



## Checklist:

-   [ ] I have performed a self-review of my own code.
-   [ ] I have linked my DevOps task using the AB# tag.
-   [ ] My code is easy to read, and comments are added where needed.
-   [ ] My code is covered by tests.
