### PR TITLE
Custom column widths + 100% table width

### DIFF
--- a/src/Core/WorkSpace/src/Tabs/ListTab.tsx
+++ b/src/Core/WorkSpace/src/Tabs/ListTab.tsx
@@ -14,6 +14,7 @@ export const ListTab = (): JSX.Element => {
         customCellView: tableOptions?.customCellView,
         headers: tableOptions?.headers,
         customColumns: tableOptions?.customColumns,
+        hiddenColumnsCount: tableOptions?.hiddenColumns?.length,
     });
     const hiddenCols = tableOptions?.hiddenColumns === undefined ? [] : tableOptions.hiddenColumns;
     return (

--- a/src/apps/HeatTraceInstallation/HeatTraceInstallationApp.tsx
+++ b/src/apps/HeatTraceInstallation/HeatTraceInstallationApp.tsx
@@ -26,7 +26,7 @@ export function setup(appApi: ClientApi): void {
         hiddenColumns: ['tagTree'],
         enableSelectRows: true,
         headers: [
-            { key: 'name', title: 'Name' },
+            { key: 'name', title: 'Name', width: 1000 },
             { key: 'description', title: 'Description' },
             { key: 'checklists', title: 'Checklists' },
             { key: 'lineAndSpools', title: 'Line and spools' },

--- a/src/packages/Table/Components/Styles.ts
+++ b/src/packages/Table/Components/Styles.ts
@@ -32,7 +32,7 @@ export const TableRow = styled.div<{ selected?: boolean }>`
 `;
 
 export const TableHeadCell = styled.div<{ align?: string }>`
-    padding: 10px 0px 0px 10px;
+    padding: 0px 0px 0px 10px;
     flex-direction: row;
 
     font-size: 0.875rem;

--- a/src/packages/Table/Utils/ColumnDefault.tsx
+++ b/src/packages/Table/Utils/ColumnDefault.tsx
@@ -5,9 +5,9 @@ import { Column, TableData } from '../types';
 export const createDefaultColumn = <T extends TableData>(
     props?: TableOptions<T>
 ): Partial<Column<T>> => ({
-    minWidth: 30,
+    minWidth: 100,
     width: 150,
-    maxWidth: 500,
+    maxWidth: window.innerWidth - 85,
 
     ...(props?.defaultColumn || {}),
 });

--- a/src/packages/Table/Utils/columnGenerators.tsx
+++ b/src/packages/Table/Utils/columnGenerators.tsx
@@ -6,19 +6,24 @@ const Count = styled.span`
     font-size: 12px;
     padding-left: 0.5rem;
 `;
+
 export type GenerateColumnArgs<D extends TableData> = {
     key: string;
     headers: CustomHeader<D>[] | undefined;
+    columnCount: number;
+    totalCustomColumnWidth: number;
+    customWidth?: number;
 };
 
 export type GenerateCustomColumnArgs<D extends TableData> = GenerateColumnArgs<D> & {
     customCellView: CustomCell<D>[];
 };
 
+const minimumTableWidth = window.innerWidth - 85; //85 is left sidebar menu width
 export const generateCustomColumn = <D extends TableData>(
     args: GenerateCustomColumnArgs<D>
 ): Column<D> => {
-    const { key, headers, customCellView } = args;
+    const { key, headers, customCellView, columnCount, totalCustomColumnWidth, customWidth } = args;
     return {
         id: key,
         accessor: (keys) => ({
@@ -27,9 +32,12 @@ export const generateCustomColumn = <D extends TableData>(
             cellAttributeFn: findCellFn(customCellView, key),
         }),
         Header: findCustomHeader(key, headers),
-        minWidth: 30,
-        width: 150,
-        maxWidth: 400,
+        minWidth: customWidth !== undefined ? 0 : 150,
+        width:
+            customWidth !== undefined
+                ? customWidth
+                : (minimumTableWidth - totalCustomColumnWidth) / columnCount,
+        maxWidth: minimumTableWidth,
         Cell: findCustomCell(key, customCellView),
         aggregate: 'count',
         Aggregated: (cell) => {
@@ -51,16 +59,19 @@ export const generateCustomColumn = <D extends TableData>(
 export const generateArrayColumn = <D extends TableData>(
     args: GenerateColumnArgs<D>
 ): Column<D> => {
-    const { headers, key } = args;
+    const { headers, key, columnCount, totalCustomColumnWidth, customWidth } = args;
     return {
         id: key,
         accessor: (row) => {
             return (row[key] as Array<unknown>)?.length;
         },
         Header: findCustomHeader(key, headers),
-        minWidth: 30,
-        width: 150,
-        maxWidth: 400,
+        minWidth: customWidth !== undefined ? 0 : 150,
+        width:
+            customWidth !== undefined
+                ? customWidth
+                : (minimumTableWidth - totalCustomColumnWidth) / columnCount,
+        maxWidth: minimumTableWidth,
         aggregate: 'count',
         Cell: ({ value }) => {
             return `items(${value})`;
@@ -90,13 +101,16 @@ export const generateObjectColumn = <D extends TableData>(
 };
 
 export const generateOthersColumn = <D extends TableData>(args: GenerateColumnArgs<D>) => {
-    const { key, headers } = args;
+    const { key, headers, columnCount, totalCustomColumnWidth, customWidth } = args;
     return {
         accessor: key as keyof D,
         Header: findCustomHeader(key, headers),
-        minWidth: 30,
-        width: 150,
-        maxWidth: 400,
+        minWidth: customWidth !== undefined ? 0 : 150,
+        width:
+            customWidth !== undefined
+                ? customWidth
+                : (minimumTableWidth - totalCustomColumnWidth) / columnCount,
+        maxWidth: minimumTableWidth,
         aggregate: 'count',
         Aggregated: (cell) => {
             return (

--- a/src/packages/Table/Utils/columnGenerators.tsx
+++ b/src/packages/Table/Utils/columnGenerators.tsx
@@ -37,7 +37,6 @@ export const generateCustomColumn = <D extends TableData>(
             customWidth !== undefined
                 ? customWidth
                 : (minimumTableWidth - totalCustomColumnWidth) / columnCount,
-        maxWidth: minimumTableWidth,
         Cell: findCustomCell(key, customCellView),
         aggregate: 'count',
         Aggregated: (cell) => {
@@ -71,7 +70,6 @@ export const generateArrayColumn = <D extends TableData>(
             customWidth !== undefined
                 ? customWidth
                 : (minimumTableWidth - totalCustomColumnWidth) / columnCount,
-        maxWidth: minimumTableWidth,
         aggregate: 'count',
         Cell: ({ value }) => {
             return `items(${value})`;
@@ -110,7 +108,6 @@ export const generateOthersColumn = <D extends TableData>(args: GenerateColumnAr
             customWidth !== undefined
                 ? customWidth
                 : (minimumTableWidth - totalCustomColumnWidth) / columnCount,
-        maxWidth: minimumTableWidth,
         aggregate: 'count',
         Aggregated: (cell) => {
             return (

--- a/src/packages/Table/Utils/generateColumns.tsx
+++ b/src/packages/Table/Utils/generateColumns.tsx
@@ -23,6 +23,11 @@ export const generateHeaderKeys = <D extends TableData>(
             column.width !== undefined ? column.width : 0;
         return column;
     });
+    options?.customColumns?.map((column) => {
+        totalCustomColumnWidth = totalCustomColumnWidth +=
+            typeof column.width === 'number' ? column.width : 0;
+        return column;
+    });
 
     const defaultColumns: Column<D>[] = Object.keys(headerItem).map((key): Column<D> => {
         const columnsWithCustomWidth = options?.headers?.filter(
@@ -32,7 +37,8 @@ export const generateHeaderKeys = <D extends TableData>(
             Object.keys(headerItem).length +
             (options?.customColumns?.length !== undefined ? options?.customColumns.length : 0) -
             (options?.hiddenColumnsCount !== undefined ? options?.hiddenColumnsCount : 0) -
-            (columnsWithCustomWidth !== undefined ? columnsWithCustomWidth : 0);
+            (columnsWithCustomWidth !== undefined ? columnsWithCustomWidth : 0) -
+            (options?.customColumns?.length !== undefined ? options?.customColumns.length : 0);
         const customWidth = findCustomColumnWidth(key, options?.headers);
         if (hasCustomCell(key, options?.customCellView)) {
             return generateCustomColumn({

--- a/src/packages/Table/Utils/generateColumns.tsx
+++ b/src/packages/Table/Utils/generateColumns.tsx
@@ -5,7 +5,7 @@ import {
     generateObjectColumn,
     generateOthersColumn,
 } from './columnGenerators';
-import { hasCustomCell } from './utils';
+import { findCustomColumnWidth, hasCustomCell } from './utils';
 
 export interface HeaderData {
     key: string;
@@ -17,26 +17,68 @@ export const generateHeaderKeys = <D extends TableData>(
     options?: ColumnOptions<D>
 ): Array<Column<D>> => {
     if (!headerItem) return [];
+    let totalCustomColumnWidth = 0;
+    options?.headers?.map((column) => {
+        totalCustomColumnWidth = totalCustomColumnWidth +=
+            column.width !== undefined ? column.width : 0;
+        return column;
+    });
 
     const defaultColumns: Column<D>[] = Object.keys(headerItem).map((key): Column<D> => {
+        const columnsWithCustomWidth = options?.headers?.filter(
+            (header) => header?.width !== undefined
+        ).length;
+        const columnCount =
+            Object.keys(headerItem).length +
+            (options?.customColumns?.length !== undefined ? options?.customColumns.length : 0) -
+            (options?.hiddenColumnsCount !== undefined ? options?.hiddenColumnsCount : 0) -
+            (columnsWithCustomWidth !== undefined ? columnsWithCustomWidth : 0);
+        const customWidth = findCustomColumnWidth(key, options?.headers);
         if (hasCustomCell(key, options?.customCellView)) {
             return generateCustomColumn({
                 headers: options?.headers,
                 key,
                 customCellView: options!.customCellView!,
+                columnCount: columnCount,
+                customWidth: customWidth,
+                totalCustomColumnWidth: totalCustomColumnWidth,
             });
         }
         if (Array.isArray(headerItem[key])) {
-            return generateArrayColumn({ headers: options?.headers, key });
+            return generateArrayColumn({
+                headers: options?.headers,
+                key,
+                columnCount,
+                totalCustomColumnWidth,
+                customWidth,
+            });
         }
         if (headerItem[key] === null) {
-            return generateOthersColumn({ headers: options?.headers, key });
+            return generateOthersColumn({
+                headers: options?.headers,
+                key,
+                columnCount,
+                totalCustomColumnWidth,
+                customWidth,
+            });
         }
         if (typeof headerItem[key] === 'object') {
-            return generateObjectColumn({ headers: options?.headers, key });
+            return generateObjectColumn({
+                headers: options?.headers,
+                key,
+                columnCount,
+                totalCustomColumnWidth,
+                customWidth,
+            });
         }
 
-        return generateOthersColumn({ headers: options?.headers, key });
+        return generateOthersColumn({
+            headers: options?.headers,
+            key,
+            columnCount,
+            totalCustomColumnWidth,
+            customWidth,
+        });
     });
 
     return options?.customColumns

--- a/src/packages/Table/Utils/utils.tsx
+++ b/src/packages/Table/Utils/utils.tsx
@@ -15,6 +15,19 @@ export const findCustomHeader = <T extends TableData>(
     } else return key;
 };
 
+export const findCustomColumnWidth = <T extends TableData>(
+    key: keyof T,
+    headers?: CustomHeader<T>[]
+): number | undefined => {
+    if (headers === undefined || headers.length === 0) return undefined;
+
+    const customHeaderIndex = headers.findIndex((header) => header.key === key);
+
+    if (customHeaderIndex > -1) {
+        return headers[customHeaderIndex].width;
+    } else undefined;
+};
+
 const isCustomCell = <T, D extends TableData>(arg: CellType<T>): arg is CustomCellType<T, D> => {
     return (arg as CustomCellType<T, D>).Cell !== undefined;
 };

--- a/src/packages/Table/types.ts
+++ b/src/packages/Table/types.ts
@@ -18,6 +18,7 @@ export type ColumnOptions<T extends TableData> = {
     customColumns?: CustomColumn<T>[];
     headers?: CustomHeader<T>[];
     customCellView?: CustomCell<T>[];
+    hiddenColumnsCount?: number;
 };
 
 /**
@@ -37,7 +38,9 @@ export type CellRenderProps<T> = {
 type ObjectOrTableData<T> = T extends object ? T : TableData;
 
 export type CustomColumn<T> = Column<ObjectOrTableData<T>> &
-    Required<Pick<Column<ObjectOrTableData<T>>, 'Aggregated' | 'aggregate' | 'Header' | 'id'>>;
+    Required<
+        Pick<Column<ObjectOrTableData<T>>, 'Aggregated' | 'aggregate' | 'Header' | 'id' | 'width'>
+    >;
 
 export type CustomCellType<T, D extends TableData> = {
     /** Custom cell to be display. Has access to table data object when used as a method */
@@ -67,6 +70,9 @@ export type CustomHeader<T> = {
 
     /** Title which is shown instead of default header title */
     title: string;
+
+    /** Optional width parameter for the column in px */
+    width?: number;
 };
 
 export type Column<T extends object = TableData> = ColumnDefault<T> &


### PR DESCRIPTION
# Description

Custom column widths.
Table will always fill out 100% of available width on screen.

Completes: [AB#155003](https://dev.azure.com/Equinor/fa63ceea-8883-41e2-8823-a3b54e4be178/_workitems/edit/155003)

## Checklist:

-   [x] I have performed a self-review of my own code.
-   [x] I have linked my DevOps task using the AB# tag.
-   [x] My code is easy to read, and comments are added where needed.
-   [ ] My code is covered by tests.
