### PR TITLE
fix: revert to older tableconfig

### DIFF
--- a/src/apps/Construction/Components/DetailsPage/tableConfig.tsx
+++ b/src/apps/Construction/Components/DetailsPage/tableConfig.tsx
@@ -1,7 +1,11 @@
-import { Column } from '@equinor/Table';
+import { CellProps, Column, TableInstance } from '@equinor/Table';
 import { WorkOrder } from '../../mocData/mockData';
-import { SumColumnFooter } from './components';
-import { columnGenerator } from './utils';
+import {
+    SumColumnFooter,
+    SumColumnFooterCount,
+    SumColumnFooterCountTotal,
+    SumColumnFooterSum,
+} from './components';
 
 export const cols: Column<WorkOrder>[] = [
     {
@@ -21,297 +25,355 @@ export const cols: Column<WorkOrder>[] = [
         ],
     },
     {
-        Header: 'W01',
+        Header: 'E10',
         Footer: () => <></>,
+        // accessor: "jobStatus",
         columns: [
-            columnGenerator({
-                id: 'W01-WOs',
-                header: 'WOs',
-                accessorKey: 'woNo',
-                aggregate: 'count',
-                footerType: {
-                    type: 'SumColumnFooterCount',
-                    fieldKey: 'jobStatusCode',
-                    value: 'W01',
-                    columnId: 'W01-WOs',
-                },
-                jobStatus: 'W01',
-            }),
-            columnGenerator({
-                id: 'W01-Est',
-                header: 'Est mhrs',
-                accessorKey: 'estimatedManHours',
-                aggregate: 'sum',
-                footerType: {
-                    type: 'SumColumnFooterSum',
-                    fieldKey: 'jobStatusCode',
-                    value: 'W01',
-                    sumKey: 'estimatedManHours',
-                },
-                jobStatus: 'W01',
+            {
+                id: 'E10-WOs',
+                Header: 'WOs',
                 width: 80,
-            }),
-        ],
-    },
-    {
-        Header: 'W02',
-        Footer: () => <></>,
-        columns: [
-            columnGenerator({
-                id: 'W02-WOs',
-                header: 'WOs',
-                accessorKey: 'woNo',
+                accessor: (row) => row.woNo,
                 aggregate: 'count',
-                footerType: {
-                    type: 'SumColumnFooterCount',
-                    fieldKey: 'jobStatusCode',
-                    value: 'W02',
-                    columnId: 'W02-WOs',
-                },
-                jobStatus: 'W02',
-            }),
-            columnGenerator({
-                id: 'W02-Est',
-                header: 'Est mhrs',
-                accessorKey: 'estimatedManHours',
-                aggregate: 'sum',
-                footerType: {
-                    type: 'SumColumnFooterSum',
-                    fieldKey: 'jobStatusCode',
-                    value: 'W02',
-                    sumKey: 'estimatedManHours',
-                },
-                jobStatus: 'W02',
-                width: 80,
-            }),
-        ],
-    },
-    {
-        Header: 'W03',
-        Footer: () => <></>,
-        columns: [
-            columnGenerator({
-                id: 'W03-WOs',
-                header: 'WOs',
-                accessorKey: 'woNo',
-                aggregate: 'count',
-                footerType: {
-                    type: 'SumColumnFooterCount',
-                    fieldKey: 'jobStatusCode',
-                    value: 'W03',
-                    columnId: 'W03-WOs',
-                },
-                jobStatus: 'W03',
-            }),
-            columnGenerator({
-                id: 'W03-Est',
-                header: 'Est mhrs',
-                accessorKey: 'estimatedManHours',
-                aggregate: 'sum',
-                footerType: {
-                    type: 'SumColumnFooterSum',
-                    fieldKey: 'jobStatusCode',
-                    value: 'W03',
-                    sumKey: 'estimatedManHours',
-                },
-                jobStatus: 'W03',
-                width: 80,
-            }),
-        ],
-    },
-    {
-        Header: 'W04',
-        Footer: () => <></>,
-        columns: [
-            columnGenerator({
-                id: 'W04-WOs',
-                header: 'WOs',
-                accessorKey: 'woNo',
-                aggregate: 'count',
-                footerType: {
-                    type: 'SumColumnFooterCount',
-                    fieldKey: 'jobStatusCode',
-                    value: 'W04',
-                    columnId: 'W04-WOs',
-                },
-                jobStatus: 'W04',
-            }),
-            columnGenerator({
-                id: 'W04-Est',
-                header: 'Est mhrs',
-                accessorKey: 'estimatedManHours',
-                aggregate: 'sum',
-                footerType: {
-                    type: 'SumColumnFooterSum',
-                    fieldKey: 'jobStatusCode',
-                    value: 'W04',
-                    sumKey: 'estimatedManHours',
-                },
-                jobStatus: 'W04',
-                width: 80,
-            }),
-        ],
-    },
-    {
-        Header: 'W05',
-        Footer: () => <></>,
-        columns: [
-            columnGenerator({
-                id: 'W05-WOs',
-                header: 'WOs',
-                accessorKey: 'woNo',
-                aggregate: 'count',
-                footerType: {
-                    type: 'SumColumnFooterCount',
-                    fieldKey: 'jobStatusCode',
-                    value: 'W05',
-                    columnId: 'W05-WOs',
-                },
-                jobStatus: 'W05',
-            }),
-            columnGenerator({
-                id: 'W05-Est',
-                header: 'Est mhrs',
-                accessorKey: 'estimatedManHours',
-                aggregate: 'sum',
-                footerType: {
-                    type: 'SumColumnFooterSum',
-                    fieldKey: 'jobStatusCode',
-                    value: 'W05',
-                    sumKey: 'estimatedManHours',
-                },
-                jobStatus: 'W05',
-                width: 80,
-            }),
-        ],
-    },
-    {
-        Header: 'W06',
-        Footer: () => <></>,
-        columns: [
-            columnGenerator({
-                id: 'W06-WOs',
-                header: 'WOs',
-                accessorKey: 'woNo',
-                aggregate: 'count',
-                footerType: {
-                    type: 'SumColumnFooterCount',
-                    fieldKey: 'jobStatusCode',
-                    value: 'W06',
-                    columnId: 'W06-WOs',
-                },
-                jobStatus: 'W06',
-            }),
+                Aggregated: ({
+                    row,
+                }: React.PropsWithChildren<CellProps<WorkOrder, any>>): number => {
+                    const count = row.subRows.reduce((acc, i) => {
+                        acc = i.original.jobStatusCode === 'W01' ? acc + 1 : acc;
+                        return acc;
+                    }, 0);
 
-            columnGenerator({
-                id: 'W06-Est',
-                header: 'Est mhrs',
-                accessorKey: 'estimatedManHours',
-                aggregate: 'sum',
-                footerType: {
-                    type: 'SumColumnFooterSum',
-                    fieldKey: 'jobStatusCode',
-                    value: 'W06',
-                    sumKey: 'estimatedManHours',
+                    return count;
                 },
-                jobStatus: 'W06',
+                Footer: (data) => (
+                    <SumColumnFooterCount
+                        data={data}
+                        fieldKey={'jobStatusCode'}
+                        value={'W01'}
+                        columnId={'E10-WOs'}
+                    />
+                ),
+            },
+            {
+                id: 'E10-Est',
+                Header: 'Est mhrs',
                 width: 80,
-            }),
+                accessor: (row) => row.estimatedManHours,
+                aggregate: 'sum',
+                Aggregated: ({
+                    row,
+                }: React.PropsWithChildren<CellProps<WorkOrder, any>>): number => {
+                    const count = row.subRows.reduce((acc, i) => {
+                        acc =
+                            i.original.jobStatusCode === 'W01'
+                                ? acc + Number(i.original.estimatedManHours) || 0
+                                : acc;
+                        return acc;
+                    }, 0);
+
+                    return count;
+                },
+                Footer: (data) => (
+                    <SumColumnFooterSum
+                        data={data}
+                        fieldKey={'jobStatusCode'}
+                        value={'W01'}
+                        sumKey={'estimatedManHours'}
+                    />
+                ),
+            },
         ],
     },
     {
-        Header: 'W07',
+        Header: 'E20',
         Footer: () => <></>,
         columns: [
-            columnGenerator({
-                id: 'W07-WOs',
-                header: 'WOs',
-                accessorKey: 'woNo',
-                aggregate: 'count',
-                footerType: {
-                    type: 'SumColumnFooterCount',
-                    fieldKey: 'jobStatusCode',
-                    value: 'W07',
-                    columnId: 'W07-WOs',
-                },
-                jobStatus: 'W07',
-            }),
-
-            columnGenerator({
-                id: 'W07-Est',
-                header: 'Est mhrs',
-                accessorKey: 'estimatedManHours',
-                aggregate: 'sum',
-                footerType: {
-                    type: 'SumColumnFooterSum',
-                    fieldKey: 'jobStatusCode',
-                    value: 'W07',
-                    sumKey: 'estimatedManHours',
-                },
-                jobStatus: 'W07',
+            {
+                id: 'E20-WOs',
+                Header: 'WOs',
                 width: 80,
-            }),
+                accessor: (item: WorkOrder): string => {
+                    return item.woNo;
+                },
+                Aggregated: ({
+                    row,
+                }: React.PropsWithChildren<CellProps<WorkOrder, any>>): number => {
+                    const count = row.subRows.reduce((acc, i) => {
+                        acc = i.original.jobStatusCode === 'W01' ? acc + 1 : acc;
+                        return acc;
+                    }, 0);
+
+                    return count;
+                },
+                aggregate: 'count',
+                Footer: (data) => (
+                    <SumColumnFooterCount
+                        data={data}
+                        fieldKey={'jobStatusCode'}
+                        value={'W02'}
+                        columnId={'E20-WOs'}
+                    />
+                ),
+            },
+            {
+                id: 'E20-Est',
+                Header: 'Est mhrs',
+                width: 80,
+                accessor: (item: WorkOrder): number => {
+                    return Number(item.estimatedManHours) || 0;
+                },
+                Aggregated: ({
+                    row,
+                }: React.PropsWithChildren<CellProps<WorkOrder, any>>): number => {
+                    const count = row.subRows.reduce((acc, i) => {
+                        acc =
+                            i.original.jobStatusCode === 'W02'
+                                ? acc + Number(i.original.estimatedManHours) || 0
+                                : acc;
+                        return acc;
+                    }, 0);
+
+                    return count;
+                },
+                aggregate: 'sum',
+                Footer: (data: React.PropsWithChildren<TableInstance<WorkOrder>>) => (
+                    <SumColumnFooterSum
+                        data={data}
+                        fieldKey={'jobStatusCode'}
+                        value={'W02'}
+                        sumKey={'estimatedManHours'}
+                    />
+                ),
+            },
         ],
     },
     {
-        Header: 'W08',
+        Header: 'E30',
         Footer: () => <></>,
         columns: [
-            columnGenerator({
-                id: 'W08-WOs',
-                header: 'WOs',
-                accessorKey: 'woNo',
-                aggregate: 'count',
-                footerType: {
-                    type: 'SumColumnFooterCount',
-                    fieldKey: 'jobStatusCode',
-                    value: 'W08',
-                    columnId: 'W08-WOs',
-                },
-                jobStatus: 'W08',
-            }),
-
-            columnGenerator({
-                id: 'W08-Est',
-                header: 'Est mhrs',
-                accessorKey: 'estimatedManHours',
-                aggregate: 'sum',
-                footerType: {
-                    type: 'SumColumnFooterSum',
-                    fieldKey: 'jobStatusCode',
-                    value: 'W08',
-                    sumKey: 'estimatedManHours',
-                },
-                jobStatus: 'W08',
+            {
+                id: 'E30-WOs',
+                Header: 'WOs',
                 width: 80,
-            }),
+                accessor: (item: WorkOrder): string => {
+                    return item.woNo;
+                },
+                aggregate: 'count',
+                Aggregated: ({
+                    row,
+                }: React.PropsWithChildren<CellProps<WorkOrder, any>>): number => {
+                    const count = row.subRows.reduce((acc, i) => {
+                        acc = i.original.jobStatusCode === 'W03' ? acc + 1 : acc;
+                        return acc;
+                    }, 0);
+
+                    return count;
+                },
+                Footer: (data: React.PropsWithChildren<TableInstance<WorkOrder>>) => (
+                    <SumColumnFooterCount
+                        data={data}
+                        fieldKey={'jobStatusCode'}
+                        value={'W03'}
+                        columnId={'E30-WOs'}
+                    />
+                ),
+            },
+            {
+                id: 'E30-Est',
+                Header: 'Est mhrs',
+                width: 80,
+                accessor: (item: WorkOrder): number => {
+                    return Number(item.estimatedManHours) || 0;
+                },
+                aggregate: 'sum',
+                Aggregated: ({
+                    row,
+                }: React.PropsWithChildren<CellProps<WorkOrder, any>>): number => {
+                    const count = row.subRows.reduce((acc, i) => {
+                        acc =
+                            i.original.jobStatusCode === 'W03'
+                                ? acc + Number(i.original.estimatedManHours) || 0
+                                : acc;
+                        return acc;
+                    }, 0);
+
+                    return count;
+                },
+                Footer: (data: React.PropsWithChildren<TableInstance<WorkOrder>>) => (
+                    <SumColumnFooterSum
+                        data={data}
+                        fieldKey={'jobStatusCode'}
+                        value={'E30'}
+                        sumKey={'estimatedManHours'}
+                    />
+                ),
+            },
+        ],
+    },
+    {
+        Header: 'E35',
+        Footer: () => <></>,
+        columns: [
+            {
+                id: 'E35-WOs',
+                Header: 'WOs',
+                width: 80,
+                accessor: (item: WorkOrder): string => {
+                    return item.woNo;
+                },
+                Aggregated: ({
+                    row,
+                }: React.PropsWithChildren<CellProps<WorkOrder, any>>): number => {
+                    const count = row.subRows.reduce((acc, i) => {
+                        acc = i.original.jobStatusCode === 'E35' ? acc + 1 : acc;
+                        return acc;
+                    }, 0);
+
+                    return count;
+                },
+                aggregate: 'count',
+                Footer: (data: React.PropsWithChildren<TableInstance<WorkOrder>>) => (
+                    <SumColumnFooterCount
+                        data={data}
+                        fieldKey={'jobStatusCode'}
+                        value={'E35'}
+                        columnId={'E35-WOs'}
+                    />
+                ),
+            },
+            {
+                id: 'E35-Est',
+                Header: 'Est mhrs',
+                width: 80,
+                accessor: (item: WorkOrder): number => {
+                    return Number(item.estimatedManHours) || 0;
+                },
+                Aggregated: ({
+                    row,
+                }: React.PropsWithChildren<CellProps<WorkOrder, any>>): number => {
+                    const count = row.subRows.reduce((acc, i) => {
+                        acc =
+                            i.original.jobStatusCode === 'E35'
+                                ? acc + Number(i.original.estimatedManHours) || 0
+                                : acc;
+                        return acc;
+                    }, 0);
+
+                    return count;
+                },
+                aggregate: 'sum',
+                Footer: (data: React.PropsWithChildren<TableInstance<WorkOrder>>) => (
+                    <SumColumnFooterSum
+                        data={data}
+                        fieldKey={'jobStatusCode'}
+                        value={'E35'}
+                        sumKey={'estimatedManHours'}
+                    />
+                ),
+            },
+        ],
+    },
+    {
+        Header: 'E40',
+        Footer: () => <></>,
+        columns: [
+            {
+                id: 'E40-WOs',
+                Header: 'WOs',
+                width: 80,
+                accessor: (item: WorkOrder): string => {
+                    return item.woNo;
+                },
+                Aggregated: ({
+                    row,
+                }: React.PropsWithChildren<CellProps<WorkOrder, any>>): number => {
+                    const count = row.subRows.reduce((acc, i) => {
+                        acc = i.original.jobStatusCode === 'E40' ? acc + 1 : acc;
+                        return acc;
+                    }, 0);
+
+                    return count;
+                },
+                aggregate: 'count',
+                Footer: (data: React.PropsWithChildren<TableInstance<WorkOrder>>) => (
+                    <SumColumnFooterCount
+                        data={data}
+                        fieldKey={'jobStatusCode'}
+                        value={'E40'}
+                        columnId={'E40-WOs'}
+                    />
+                ),
+            },
+            {
+                id: 'E40-Est',
+                Header: 'Est mhrs',
+                width: 80,
+                accessor: (item: WorkOrder): number => {
+                    return Number(item.estimatedManHours);
+                },
+                Aggregated: ({
+                    row,
+                }: React.PropsWithChildren<CellProps<WorkOrder, any>>): number => {
+                    const count = row.subRows.reduce((acc, i) => {
+                        acc =
+                            i.original.jobStatusCode === 'E40'
+                                ? acc + Number(i.original.estimatedManHours)
+                                : acc;
+                        return acc;
+                    }, 0);
+
+                    return count;
+                },
+                aggregate: 'sum',
+                Footer: (data) => (
+                    <SumColumnFooterSum
+                        data={data}
+                        fieldKey={'jobStatusCode'}
+                        value={'E40'}
+                        sumKey={'estimatedManHours'}
+                    />
+                ),
+            },
         ],
     },
     {
         Header: 'Total',
         Footer: () => <></>,
         columns: [
-            columnGenerator({
+            {
                 id: 'Total-WOs',
-                header: 'WOs',
-                accessorKey: 'disciplineDescription',
+                Header: 'WOs',
+                width: 100,
+                accessor: (item: WorkOrder): string => {
+                    return item.responsibleCode;
+                },
                 aggregate: 'count',
-                footerType: {
-                    type: 'SumColumnFooter',
-                    columnId: 'Total-WOs',
+                Footer: (data: React.PropsWithChildren<TableInstance<WorkOrder>>): JSX.Element => {
+                    return <SumColumnFooter data={data} columnId={'Total-WOs'} />;
                 },
-                jobStatus: 'W08',
-            }),
-            columnGenerator({
+            },
+            {
                 id: 'Total-Est',
-                header: 'Est mhrs',
-                accessorKey: 'estimatedManHours',
-                aggregate: 'sum',
-                footerType: {
-                    type: 'SumColumnFooterCountTotal',
-                    fieldKey: 'estimatedManHours',
+                Header: 'Est mhrs',
+                width: 100,
+                accessor: (item: WorkOrder): number => {
+                    return Number(item.estimatedManHours) || 0;
                 },
-            }),
+                Aggregated: ({
+                    row,
+                }: React.PropsWithChildren<CellProps<WorkOrder, any>>): number => {
+                    const count = row.subRows.reduce((acc, i) => {
+                        acc = acc + Number(i.original.estimatedManHours) || 0;
+                        return acc;
+                    }, 0);
+
+                    return count;
+                },
+                aggregate: 'sum',
+                Footer: (data: React.PropsWithChildren<TableInstance<WorkOrder>>) => (
+                    <SumColumnFooterCountTotal data={data} fieldKey={'estimatedManHours'} />
+                ),
+            },
         ],
     },
 ];

--- a/src/apps/Construction/Components/DetailsPage/tableConfig.tsx
+++ b/src/apps/Construction/Components/DetailsPage/tableConfig.tsx
@@ -25,12 +25,12 @@ export const cols: Column<WorkOrder>[] = [
         ],
     },
     {
-        Header: 'E10',
+        Header: 'W01',
         Footer: () => <></>,
         // accessor: "jobStatus",
         columns: [
             {
-                id: 'E10-WOs',
+                id: 'W01-WOs',
                 Header: 'WOs',
                 width: 80,
                 accessor: (row) => row.woNo,
@@ -50,12 +50,12 @@ export const cols: Column<WorkOrder>[] = [
                         data={data}
                         fieldKey={'jobStatusCode'}
                         value={'W01'}
-                        columnId={'E10-WOs'}
+                        columnId={'W01-WOs'}
                     />
                 ),
             },
             {
-                id: 'E10-Est',
+                id: 'W01-Est',
                 Header: 'Est mhrs',
                 width: 80,
                 accessor: (row) => row.estimatedManHours,
@@ -85,11 +85,11 @@ export const cols: Column<WorkOrder>[] = [
         ],
     },
     {
-        Header: 'E20',
+        Header: 'W02',
         Footer: () => <></>,
         columns: [
             {
-                id: 'E20-WOs',
+                id: 'W02-WOs',
                 Header: 'WOs',
                 width: 80,
                 accessor: (item: WorkOrder): string => {
@@ -99,7 +99,7 @@ export const cols: Column<WorkOrder>[] = [
                     row,
                 }: React.PropsWithChildren<CellProps<WorkOrder, any>>): number => {
                     const count = row.subRows.reduce((acc, i) => {
-                        acc = i.original.jobStatusCode === 'W01' ? acc + 1 : acc;
+                        acc = i.original.jobStatusCode === 'W02' ? acc + 1 : acc;
                         return acc;
                     }, 0);
 
@@ -111,12 +111,12 @@ export const cols: Column<WorkOrder>[] = [
                         data={data}
                         fieldKey={'jobStatusCode'}
                         value={'W02'}
-                        columnId={'E20-WOs'}
+                        columnId={'W02-WOs'}
                     />
                 ),
             },
             {
-                id: 'E20-Est',
+                id: 'W02-Est',
                 Header: 'Est mhrs',
                 width: 80,
                 accessor: (item: WorkOrder): number => {
@@ -148,11 +148,11 @@ export const cols: Column<WorkOrder>[] = [
         ],
     },
     {
-        Header: 'E30',
+        Header: 'W03',
         Footer: () => <></>,
         columns: [
             {
-                id: 'E30-WOs',
+                id: 'W03-WOs',
                 Header: 'WOs',
                 width: 80,
                 accessor: (item: WorkOrder): string => {
@@ -174,12 +174,12 @@ export const cols: Column<WorkOrder>[] = [
                         data={data}
                         fieldKey={'jobStatusCode'}
                         value={'W03'}
-                        columnId={'E30-WOs'}
+                        columnId={'W03-WOs'}
                     />
                 ),
             },
             {
-                id: 'E30-Est',
+                id: 'W03-Est',
                 Header: 'Est mhrs',
                 width: 80,
                 accessor: (item: WorkOrder): number => {
@@ -203,7 +203,7 @@ export const cols: Column<WorkOrder>[] = [
                     <SumColumnFooterSum
                         data={data}
                         fieldKey={'jobStatusCode'}
-                        value={'E30'}
+                        value={'W03'}
                         sumKey={'estimatedManHours'}
                     />
                 ),
@@ -211,11 +211,11 @@ export const cols: Column<WorkOrder>[] = [
         ],
     },
     {
-        Header: 'E35',
+        Header: 'W04',
         Footer: () => <></>,
         columns: [
             {
-                id: 'E35-WOs',
+                id: 'W04-WOs',
                 Header: 'WOs',
                 width: 80,
                 accessor: (item: WorkOrder): string => {
@@ -225,7 +225,7 @@ export const cols: Column<WorkOrder>[] = [
                     row,
                 }: React.PropsWithChildren<CellProps<WorkOrder, any>>): number => {
                     const count = row.subRows.reduce((acc, i) => {
-                        acc = i.original.jobStatusCode === 'E35' ? acc + 1 : acc;
+                        acc = i.original.jobStatusCode === 'W04' ? acc + 1 : acc;
                         return acc;
                     }, 0);
 
@@ -236,13 +236,13 @@ export const cols: Column<WorkOrder>[] = [
                     <SumColumnFooterCount
                         data={data}
                         fieldKey={'jobStatusCode'}
-                        value={'E35'}
-                        columnId={'E35-WOs'}
+                        value={'W04'}
+                        columnId={'W04-WOs'}
                     />
                 ),
             },
             {
-                id: 'E35-Est',
+                id: 'W04-Est',
                 Header: 'Est mhrs',
                 width: 80,
                 accessor: (item: WorkOrder): number => {
@@ -253,7 +253,7 @@ export const cols: Column<WorkOrder>[] = [
                 }: React.PropsWithChildren<CellProps<WorkOrder, any>>): number => {
                     const count = row.subRows.reduce((acc, i) => {
                         acc =
-                            i.original.jobStatusCode === 'E35'
+                            i.original.jobStatusCode === 'W04'
                                 ? acc + Number(i.original.estimatedManHours) || 0
                                 : acc;
                         return acc;
@@ -266,19 +266,20 @@ export const cols: Column<WorkOrder>[] = [
                     <SumColumnFooterSum
                         data={data}
                         fieldKey={'jobStatusCode'}
-                        value={'E35'}
+                        value={'W04'}
                         sumKey={'estimatedManHours'}
                     />
                 ),
             },
         ],
     },
+
     {
-        Header: 'E40',
+        Header: 'W05',
         Footer: () => <></>,
         columns: [
             {
-                id: 'E40-WOs',
+                id: 'W05-WOs',
                 Header: 'WOs',
                 width: 80,
                 accessor: (item: WorkOrder): string => {
@@ -288,7 +289,7 @@ export const cols: Column<WorkOrder>[] = [
                     row,
                 }: React.PropsWithChildren<CellProps<WorkOrder, any>>): number => {
                     const count = row.subRows.reduce((acc, i) => {
-                        acc = i.original.jobStatusCode === 'E40' ? acc + 1 : acc;
+                        acc = i.original.jobStatusCode === 'W05' ? acc + 1 : acc;
                         return acc;
                     }, 0);
 
@@ -299,13 +300,13 @@ export const cols: Column<WorkOrder>[] = [
                     <SumColumnFooterCount
                         data={data}
                         fieldKey={'jobStatusCode'}
-                        value={'E40'}
-                        columnId={'E40-WOs'}
+                        value={'W05'}
+                        columnId={'W05-WOs'}
                     />
                 ),
             },
             {
-                id: 'E40-Est',
+                id: 'W05-Est',
                 Header: 'Est mhrs',
                 width: 80,
                 accessor: (item: WorkOrder): number => {
@@ -316,7 +317,7 @@ export const cols: Column<WorkOrder>[] = [
                 }: React.PropsWithChildren<CellProps<WorkOrder, any>>): number => {
                     const count = row.subRows.reduce((acc, i) => {
                         acc =
-                            i.original.jobStatusCode === 'E40'
+                            i.original.jobStatusCode === 'W05'
                                 ? acc + Number(i.original.estimatedManHours)
                                 : acc;
                         return acc;
@@ -329,7 +330,196 @@ export const cols: Column<WorkOrder>[] = [
                     <SumColumnFooterSum
                         data={data}
                         fieldKey={'jobStatusCode'}
-                        value={'E40'}
+                        value={'W05'}
+                        sumKey={'estimatedManHours'}
+                    />
+                ),
+            },
+        ],
+    },
+    {
+        Header: 'W06',
+        Footer: () => <></>,
+        columns: [
+            {
+                id: 'W06-WOs',
+                Header: 'WOs',
+                width: 80,
+                accessor: (item: WorkOrder): string => {
+                    return item.woNo;
+                },
+                Aggregated: ({
+                    row,
+                }: React.PropsWithChildren<CellProps<WorkOrder, any>>): number => {
+                    const count = row.subRows.reduce((acc, i) => {
+                        acc = i.original.jobStatusCode === 'W06' ? acc + 1 : acc;
+                        return acc;
+                    }, 0);
+
+                    return count;
+                },
+                aggregate: 'count',
+                Footer: (data: React.PropsWithChildren<TableInstance<WorkOrder>>) => (
+                    <SumColumnFooterCount
+                        data={data}
+                        fieldKey={'jobStatusCode'}
+                        value={'W06'}
+                        columnId={'W06-WOs'}
+                    />
+                ),
+            },
+            {
+                id: 'W06-Est',
+                Header: 'Est mhrs',
+                width: 80,
+                accessor: (item: WorkOrder): number => {
+                    return Number(item.estimatedManHours);
+                },
+                Aggregated: ({
+                    row,
+                }: React.PropsWithChildren<CellProps<WorkOrder, any>>): number => {
+                    const count = row.subRows.reduce((acc, i) => {
+                        acc =
+                            i.original.jobStatusCode === 'W06'
+                                ? acc + Number(i.original.estimatedManHours)
+                                : acc;
+                        return acc;
+                    }, 0);
+
+                    return count;
+                },
+                aggregate: 'sum',
+                Footer: (data) => (
+                    <SumColumnFooterSum
+                        data={data}
+                        fieldKey={'jobStatusCode'}
+                        value={'W06'}
+                        sumKey={'estimatedManHours'}
+                    />
+                ),
+            },
+        ],
+    },
+    {
+        Header: 'W07',
+        Footer: () => <></>,
+        columns: [
+            {
+                id: 'W07-WOs',
+                Header: 'WOs',
+                width: 80,
+                accessor: (item: WorkOrder): string => {
+                    return item.woNo;
+                },
+                Aggregated: ({
+                    row,
+                }: React.PropsWithChildren<CellProps<WorkOrder, any>>): number => {
+                    const count = row.subRows.reduce((acc, i) => {
+                        acc = i.original.jobStatusCode === 'W07' ? acc + 1 : acc;
+                        return acc;
+                    }, 0);
+
+                    return count;
+                },
+                aggregate: 'count',
+                Footer: (data: React.PropsWithChildren<TableInstance<WorkOrder>>) => (
+                    <SumColumnFooterCount
+                        data={data}
+                        fieldKey={'jobStatusCode'}
+                        value={'W07'}
+                        columnId={'W07-WOs'}
+                    />
+                ),
+            },
+            {
+                id: 'W07-Est',
+                Header: 'Est mhrs',
+                width: 80,
+                accessor: (item: WorkOrder): number => {
+                    return Number(item.estimatedManHours);
+                },
+                Aggregated: ({
+                    row,
+                }: React.PropsWithChildren<CellProps<WorkOrder, any>>): number => {
+                    const count = row.subRows.reduce((acc, i) => {
+                        acc =
+                            i.original.jobStatusCode === 'W07'
+                                ? acc + Number(i.original.estimatedManHours)
+                                : acc;
+                        return acc;
+                    }, 0);
+
+                    return count;
+                },
+                aggregate: 'sum',
+                Footer: (data) => (
+                    <SumColumnFooterSum
+                        data={data}
+                        fieldKey={'jobStatusCode'}
+                        value={'W07'}
+                        sumKey={'estimatedManHours'}
+                    />
+                ),
+            },
+        ],
+    },
+    {
+        Header: 'W08',
+        Footer: () => <></>,
+        columns: [
+            {
+                id: 'W08-WOs',
+                Header: 'WOs',
+                width: 80,
+                accessor: (item: WorkOrder): string => {
+                    return item.woNo;
+                },
+                Aggregated: ({
+                    row,
+                }: React.PropsWithChildren<CellProps<WorkOrder, any>>): number => {
+                    const count = row.subRows.reduce((acc, i) => {
+                        acc = i.original.jobStatusCode === 'W08' ? acc + 1 : acc;
+                        return acc;
+                    }, 0);
+
+                    return count;
+                },
+                aggregate: 'count',
+                Footer: (data: React.PropsWithChildren<TableInstance<WorkOrder>>) => (
+                    <SumColumnFooterCount
+                        data={data}
+                        fieldKey={'jobStatusCode'}
+                        value={'W08'}
+                        columnId={'W08-WOs'}
+                    />
+                ),
+            },
+            {
+                id: 'W08-Est',
+                Header: 'Est mhrs',
+                width: 80,
+                accessor: (item: WorkOrder): number => {
+                    return Number(item.estimatedManHours);
+                },
+                Aggregated: ({
+                    row,
+                }: React.PropsWithChildren<CellProps<WorkOrder, any>>): number => {
+                    const count = row.subRows.reduce((acc, i) => {
+                        acc =
+                            i.original.jobStatusCode === 'W08'
+                                ? acc + Number(i.original.estimatedManHours)
+                                : acc;
+                        return acc;
+                    }, 0);
+
+                    return count;
+                },
+                aggregate: 'sum',
+                Footer: (data) => (
+                    <SumColumnFooterSum
+                        data={data}
+                        fieldKey={'jobStatusCode'}
+                        value={'W08'}
                         sumKey={'estimatedManHours'}
                     />
                 ),

--- a/src/apps/Construction/Components/DetailsPage/utils.tsx
+++ b/src/apps/Construction/Components/DetailsPage/utils.tsx
@@ -1,4 +1,4 @@
-import { CellProps, TableInstance, Column } from '@equinor/Table';
+import { CellProps, TableInstance } from '@equinor/Table';
 import {
     SumColumnFooter,
     SumColumnFooterCount,
@@ -15,7 +15,7 @@ import { ColumnGeneratorArgs } from './types';
  */
 export const columnGenerator = <T extends Record<string, unknown>>(
     args: ColumnGeneratorArgs<T>
-): Column<T> => {
+) => {
     const { id, header, accessorKey, aggregate, footerType, jobStatus, width = 100 } = args;
     return {
         id,


### PR DESCRIPTION
# Description

Please include a summary of the change and which issue is fixed.
List any external dependencies that are required for this change.
A commit from #120 made tsc super slow (adding type to this huge column config and using functions to return different object). 
Before:
Files:             1894
Lines:           373965
Nodes:           698977
Identifiers:     227992
Symbols:         387970
Types:           100351
Instantiations:  895822
Memory used:    427975K
I/O read:         0.16s
I/O write:        0.00s
Parse time:       3.76s
Bind time:        1.19s
Check time:      53.91s
Emit time:        0.00s
Total time:      58.86s

Now: 
Files:             1893
Lines:           373987
Nodes:           699772
Identifiers:     228276
Symbols:         388426
Types:           103230
Instantiations:  885151
Memory used:    429050K
I/O read:         0.09s
I/O write:        0.00s
Parse time:       2.17s
Bind time:        0.69s
Check time:       7.15s
Emit time:        0.00s
Total time:      10.00s
## Checklist:

-   [ ] I have performed a self-review of my own code.
-   [ ] I have linked my DevOps task using the AB# tag.
-   [ ] My code is easy to read, and comments are added where needed.
-   [ ] My code is covered by tests.
