### PR TITLE
[PowerBI] - Fix: Only affect visible filter items with select all

### DIFF
--- a/src/modules/powerBI/src/Components/Filter/FilterItems/FilterItems.tsx
+++ b/src/modules/powerBI/src/Components/Filter/FilterItems/FilterItems.tsx
@@ -13,7 +13,11 @@ type FilterItemsProps = {
         filter: PowerBiFilterItem,
         singleClick?: boolean
     ) => Promise<void>;
-    handleOnSelectAll: (group: PowerBiFilter, filter: PowerBiFilterItem) => Promise<void>;
+    handleOnSelectAll: (
+        group: PowerBiFilter,
+        filter: PowerBiFilterItem,
+        allVisibleFilterValues: string[]
+    ) => Promise<void>;
     activeFilters: Record<string, (string | number | boolean)[]>;
     group: PowerBiFilter;
 };
@@ -33,17 +37,23 @@ export const FilterItems = ({
 
     if (filterGroupVisible.includes(group.type)) {
         const filterValues = Object.values(group.value);
+        const searchedFilterItems = searchFilterItems(filterValues, searchValue);
+        const allSearchedFilterValues = searchedFilterItems.map((x) => x.value);
         return (
             <FilterGroupContainer>
                 <Header title={group.type} onSearch={handleOnSearchChange} />
                 <CheckboxWrap>
                     <Checkbox
-                        onChange={async () => await handleOnSelectAll(group, filterValues[0])}
-                        checked={activeFilters[group.type]?.length === filterValues.length}
+                        onChange={async () =>
+                            await handleOnSelectAll(group, filterValues[0], allSearchedFilterValues)
+                        }
+                        checked={allSearchedFilterValues.every((a) =>
+                            activeFilters[group.type]?.includes(a)
+                        )}
                         label="Select all"
                     />
 
-                    {searchFilterItems(filterValues, searchValue).map((filter) => {
+                    {searchedFilterItems.map((filter) => {
                         return (
                             <Item
                                 activeFilters={activeFilters[filter.type] || []}

--- a/src/modules/powerBI/src/Components/Filter/FilterItems/FilterItems.tsx
+++ b/src/modules/powerBI/src/Components/Filter/FilterItems/FilterItems.tsx
@@ -47,8 +47,8 @@ export const FilterItems = ({
                         onChange={async () =>
                             await handleOnSelectAll(group, filterValues[0], allSearchedFilterValues)
                         }
-                        checked={allSearchedFilterValues.every((a) =>
-                            activeFilters[group.type]?.includes(a)
+                        checked={allSearchedFilterValues.every((visibleFilterValue) =>
+                            activeFilters[group.type]?.includes(visibleFilterValue)
                         )}
                         label="Select all"
                     />

--- a/src/modules/powerBI/src/Components/Filter/PowerBIFilter.tsx
+++ b/src/modules/powerBI/src/Components/Filter/PowerBIFilter.tsx
@@ -42,7 +42,11 @@ export const PowerBIFilter = ({
         allVisibleFilterValues: string[]
     ) => {
         try {
-            if (allVisibleFilterValues.every((a) => activeFilters[group.type]?.includes(a))) {
+            if (
+                allVisibleFilterValues.every((visibleValue) =>
+                    activeFilters[group.type]?.includes(visibleValue)
+                )
+            ) {
                 /**
                  * All visible filters are applied.
                  * Remove the visible ones, and keep the ones not visible

--- a/src/modules/powerBI/src/Components/Filter/PowerBIFilter.tsx
+++ b/src/modules/powerBI/src/Components/Filter/PowerBIFilter.tsx
@@ -33,7 +33,7 @@ export const PowerBIFilter = ({
 
     /**
      * Function to handle "Select All" checkbox.
-     * Will either add all visble filter values to current target, or remove all depending
+     * Will either add all visible filter values to current target, or remove all depending
      * on if checkbox is ticked or not.
      */
     const handleOnSelectAll = async (


### PR DESCRIPTION
# Description

When using "Select All" functionality in a filter, only the visible filters will be affected.
 Meaning if you have 5 filter items, type something in the search input so only 2 are visible, choose select all, only the 2 visible will be affected. 

Completes: AB#FILL_IN_YOUR_ISSUE_ID

## Checklist:

-   [x] I have performed a self-review of my own code.
-   [ ] I have linked my DevOps task using the AB# tag.
-   [x] My code is easy to read, and comments are added where needed.
-   [ ] My code is covered by tests.
