### PR TITLE
[PowerBI] - chore: remove hidden filters based on prefix

### DIFF
--- a/src/modules/powerBI/src/Utils/getFilters.ts
+++ b/src/modules/powerBI/src/Utils/getFilters.ts
@@ -1,7 +1,7 @@
 import { Report } from 'powerbi-client';
 import { createPowerBiFilter, getSlicerData } from '.';
 import { PowerBiFilter } from '../Types';
-
+const HIDDEN_FILTER_PREFIX = 'xx';
 /**
  * Get all slicer filters on mount and after a slicer filter is set.
  * Some filters may be removed after a slicer filter is set.
@@ -18,5 +18,5 @@ export async function getFilters(reportInstance: Report): Promise<PowerBiFilter[
         })
     );
 
-    return filters;
+    return filters.filter((f) => !f.type.startsWith(HIDDEN_FILTER_PREFIX));
 }


### PR DESCRIPTION
# Description

Certain filters that come from PowerBI shouldnt be shown in the filter pane. If such a filter exists, it will have the prefix 'xx'.

Completes: AB#FILL_IN_YOUR_ISSUE_ID

## Checklist:

-   [x] I have performed a self-review of my own code.
-   [ ] I have linked my DevOps task using the AB# tag.
-   [x] My code is easy to read, and comments are added where needed.
-   [ ] My code is covered by tests.
