### PR TITLE
[PowerBI] - fix: update state when chiclet slicers are triggered

### DIFF
--- a/src/modules/powerBI/src/PowerBI.tsx
+++ b/src/modules/powerBI/src/PowerBI.tsx
@@ -97,6 +97,17 @@ export const PowerBI = ({
         ],
         ['dataSelected', function (e) {}],
         ['selectionChanged', function (e) {}],
+        [
+            'visualClicked',
+            function (e) {
+                /**Chiclet slicers are visuals inside the report that will have an impact
+                 * on what filters are to be shown if they are clicked, so an update is needed..
+                 */
+                if ((e.detail.visual.type as string).startsWith('Chiclet')) {
+                    setIsLoaded(false);
+                }
+            },
+        ],
     ]);
     return (
         <>


### PR DESCRIPTION
# Description
Inside a PowerBI report there may be "chiclet slicers". If one of these are clicked, it will have an impact on the filters that can be applied. We only want to cause this state update when the type of the slicer is "chiclet", so we can prevent unnecessary state updates when other visuals are clicked. 

Completes: AB#FILL_IN_YOUR_ISSUE_ID

## Checklist:

-   [ ] I have performed a self-review of my own code.
-   [ ] I have linked my DevOps task using the AB# tag.
-   [ ] My code is easy to read, and comments are added where needed.
-   [ ] My code is covered by tests.
