### PR TITLE
[Handover] - chore: fixed size on handover package and header

### DIFF
--- a/src/apps/Handover/Garden/CustomViews/HandoverGardenHeader.tsx
+++ b/src/apps/Handover/Garden/CustomViews/HandoverGardenHeader.tsx
@@ -10,7 +10,7 @@ export const Title = styled.p`
 
 export const Groupe = styled.div`
     padding: 0.1rem;
-    min-width: 200px;
+    width: 180px;
     display: flex;
     align-items: center;
     position: relative;

--- a/src/apps/Handover/Garden/CustomViews/HandoverGardenItem/GardenItemStyles.ts
+++ b/src/apps/Handover/Garden/CustomViews/HandoverGardenItem/GardenItemStyles.ts
@@ -1,18 +1,19 @@
 import styled from 'styled-components';
 import { Item } from '../../../../../components/ParkView/Styles/item';
 
-export type HandoverItemProps = { backgroundColor: string; textColor: string };
+export type HandoverItemProps = { backgroundColor: string; textColor: string; isExpanded: boolean };
 
 export const HandoverItem = styled(Item)<HandoverItemProps>`
     display: flex;
     background: ${(props) => props.backgroundColor};
     color: ${(props) => props.textColor};
-    width: 100%;
-    min-width: 150px;
+    width: ${(props) => (props.isExpanded ? '100%' : '180px')};
     box-sizing: border-box;
     white-space: nowrap;
     justify-content: space-between;
     border: 1px solid #dcdcdc;
+    height: 28px;
+    align-items: center;
 `;
 
 export const MidSection = styled.div<{ expanded: boolean }>`

--- a/src/apps/Handover/Garden/CustomViews/HandoverGardenItem/HandoverGardenItem.tsx
+++ b/src/apps/Handover/Garden/CustomViews/HandoverGardenItem/HandoverGardenItem.tsx
@@ -67,6 +67,7 @@ export function HandoverGardenItem({
                 backgroundColor={backgroundColor}
                 textColor={textColor}
                 onClick={onClick}
+                isExpanded={columnExpanded}
             >
                 <Icons>
                     <SizeIcons size={size} status={status} />


### PR DESCRIPTION
# Description

It's a wish to have the handover package item to be 180x28px 
When expanded the width will be 100%.
When multiple group by's it will be a bit smaller than the group by item, not sure yet what is wanted there still WIP.

Completes: AB#FILL_IN_YOUR_ISSUE_ID

## Checklist:

-   [ ] I have performed a self-review of my own code.
-   [ ] I have linked my DevOps task using the AB# tag.
-   [ ] My code is easy to read, and comments are added where needed.
-   [ ] My code is covered by tests.
