### PR TITLE
[Workspace] - hotfix: changing workspace bug

### DIFF
--- a/src/Core/WorkSpace/src/Components/DataViewerHeader/Header.tsx
+++ b/src/Core/WorkSpace/src/Components/DataViewerHeader/Header.tsx
@@ -9,6 +9,7 @@ import { useSettings } from '../../../../Client/Hooks';
 import { PerformanceObserver } from '../../../../PerformanceObserver/PerformanceObserver';
 import { useDataContext } from '../../Context/DataProvider';
 import { useIntervalTimestamp } from '../../Hooks/useIntervalTimestamp';
+import { useWorkSpace } from '../../WorkSpaceApi/useWorkSpace';
 import { TabButton } from '../ToggleButton';
 import { Divider, HeaderWrapper, LeftSection, RightSection, Title, TitleBar } from './HeaderStyles';
 
@@ -34,11 +35,11 @@ export const CompletionViewHeader = ({
     handleFilter,
     activeFilter,
 }: CompletionViewHeaderProps): JSX.Element => {
-    const { statusFunc, key, dataApi } = useDataContext();
+    const { key, dataApi } = useDataContext();
+    const { statusFunc } = useWorkSpace();
     const { factory, setSelected } = useFactory(key);
     const { data } = useFilteredData();
     const timestamp = useIntervalTimestamp(dataApi?.dataUpdatedAt);
-
     const { clientEnv } = useSettings();
 
     return (

--- a/src/Core/WorkSpace/src/Components/WorkSpace/HeaderFilterWrapper.tsx
+++ b/src/Core/WorkSpace/src/Components/WorkSpace/HeaderFilterWrapper.tsx
@@ -1,8 +1,9 @@
 import { FilterView } from '@equinor/filter';
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 import { WorkspaceProps } from '../..';
 import { TabsConfigItem } from '../../Tabs/tabsConfig';
 import { CompletionViewHeader } from '../DataViewerHeader/Header';
+import { useWorkSpaceKey } from '../DefaultView/Hooks/useWorkspaceKey';
 
 type HeaderWrapperProps = {
     props: WorkspaceProps;
@@ -13,6 +14,11 @@ export const HeaderWrapper = ({ tabs, props }: HeaderWrapperProps) => {
     function handleFilter() {
         setActiveFilter((state) => !state);
     }
+    const key = useWorkSpaceKey();
+    useEffect(() => {
+        setActiveFilter(false);
+    }, [key]);
+
     return (
         <>
             <CompletionViewHeader

--- a/src/apps/DisciplineReleaseControl/Functions/tableHelpers.ts
+++ b/src/apps/DisciplineReleaseControl/Functions/tableHelpers.ts
@@ -44,7 +44,7 @@ export function getHTList(checkLists: CheckList[]): string {
 export function getPipetestsWithHTCable(pipetests: Pipetest[]): Pipetest[] {
     const pipetestsWithHTCable: Pipetest[] = [];
     pipetests.forEach((pipetest: Pipetest) => {
-        if (pipetest.checkLists.some((x) => x.isHeatTrace)) {
+        if (pipetest.checkLists?.some((x) => x.isHeatTrace)) {
             pipetestsWithHTCable.push(pipetest);
         }
     });

--- a/src/packages/Filter/Context/FilterProvider.tsx
+++ b/src/packages/Filter/Context/FilterProvider.tsx
@@ -68,6 +68,15 @@ export function FilterProvider<T>({
         dispatch(actions.setData(initialData));
     }, [initialData]);
 
+    useEffect(() => {
+        const filter = createFilterData(initialData, options);
+
+        dispatch(actions.setFilter(filter));
+        persistOptions && persistOptions.setFilter(filter);
+
+        setFilter(initialData, filter);
+    }, [options]);
+
     const filterItemCheck: FilterItemCheck = useCallback(
         (filterItem: FilterItem | FilterItem[], singleClick?: boolean): void => {
             const currentFilter = checkItem(filterData, filterItem, singleClick);


### PR DESCRIPTION
# Description
A hotfix for when switching workspaces. Resets filter state, builds new filter and statusFunc comes from useWorkspace which causes some other bug(?) in heat trace app where it tries to calculate status before data is ready.

Completes: AB#FILL_IN_YOUR_ISSUE_ID

## Checklist:

-   [ ] I have performed a self-review of my own code.
-   [ ] I have linked my DevOps task using the AB# tag.
-   [ ] My code is easy to read, and comments are added where needed.
-   [ ] My code is covered by tests.
