### PR TITLE
[Workorder & Virtual Garden] - feat: expand workorder column with description

### DIFF
--- a/src/apps/WorkOrder/Garden/components/WorkOrderItem/WorkOrderItem.tsx
+++ b/src/apps/WorkOrder/Garden/components/WorkOrderItem/WorkOrderItem.tsx
@@ -6,6 +6,7 @@ import {
     FollowUpStatuses,
 } from '@equinor/GardenUtils';
 import { memo, useCallback, useMemo, useRef, useState } from 'react';
+import styled from 'styled-components';
 import { useParkViewContext } from '../../../../../components/ParkView/Context/ParkViewProvider';
 import { CustomItemView } from '../../../../../components/ParkView/Models/gardenOptions';
 import { WorkOrder } from '../../models';
@@ -25,6 +26,7 @@ import {
     MidSection,
     WorkorderExpanded,
     WorkorderExpandedTitle,
+    Root,
 } from './styles';
 import { itemSize } from './utils';
 type PackageStatusReturn = {
@@ -67,7 +69,14 @@ const getWorkOrderStatuses = (
         status,
     };
 };
-const WorkOrderItem = ({ data, itemKey, onClick, columnExpanded }: CustomItemView<WorkOrder>) => {
+
+const WorkOrderItem = ({
+    data,
+    itemKey,
+    onClick,
+    columnExpanded,
+    width = 300,
+}: CustomItemView<WorkOrder>) => {
     const [isOpen, setIsOpen] = useState<boolean>(false);
     const anchorRef = useRef<HTMLDivElement>(null);
     const { groupByKeys, gardenKey } = useParkViewContext<WorkOrder>();
@@ -85,8 +94,9 @@ const WorkOrderItem = ({ data, itemKey, onClick, columnExpanded }: CustomItemVie
         () => getWorkOrderStatuses(data, gardenKey, groupByKeys),
         [data, gardenKey, groupByKeys]
     );
+    const maxWidth = useMemo(() => width * 0.95, [width]);
     return (
-        <>
+        <Root>
             <WorkOrderWrapper
                 backgroundColor={backgroundColor}
                 textColor={textColor}
@@ -95,19 +105,20 @@ const WorkOrderItem = ({ data, itemKey, onClick, columnExpanded }: CustomItemVie
                 onMouseOver={() => setIsOpen(true)}
                 onMouseLeave={() => setIsOpen(false)}
                 onClick={onClick}
+                style={{ maxWidth }}
             >
                 {/* <SizeIcons size={size} color={textColor} />*/}
                 {/* {data.holdBy && <FlagIcon color={textColor} />} */}
                 {data[itemKey]}
                 {'  '}
-                {columnExpanded && data.description}
+
                 <Circles>
                     <StatusCircle statusColor={matColor} />
                     <StatusCircle statusColor={mccrColor} />
                 </Circles>
                 {/* <Progress background={progressBar} /> */}
             </WorkOrderWrapper>
-
+            {columnExpanded && data.description}
             {/* {isOpen && (
                 <WorkOrderPopover
                     data={data}
@@ -124,7 +135,7 @@ const WorkOrderItem = ({ data, itemKey, onClick, columnExpanded }: CustomItemVie
                     }}
                 />
             )} */}
-        </>
+        </Root>
     );
 };
 

--- a/src/apps/WorkOrder/Garden/components/WorkOrderItem/styles.ts
+++ b/src/apps/WorkOrder/Garden/components/WorkOrderItem/styles.ts
@@ -1,20 +1,25 @@
 import styled from 'styled-components';
-import { Item } from '../../../../../components/ParkView/Styles/item';
+export const Root = styled.div`
+    height: 80%;
+    width: 100%;
+    display: flex;
+    align-items: center;
+    gap: 10px;
+    margin-left: 5px;
+`;
 export type WorkOrderItemProps = { backgroundColor: string; textColor: string; background: string };
 //@ts-ignore
-export const WorkOrderWrapper = styled(Item)<WorkOrderItemProps>`
-    position: relative;
+export const WorkOrderWrapper = styled.div<WorkOrderItemProps>`
     background: ${(props) => props.backgroundColor};
     color: ${(props) => props.textColor};
     width: 95%;
     min-width: 150px;
-    box-sizing: border-box;
-    white-space: nowrap;
-    border: 1px solid #dcdcdc;
-    height: 85%;
+    cursor: pointer;
+    height: 100%;
     display: flex;
     align-items: center;
     justify-content: space-between;
+    border-radius: 5px;
 `;
 
 export const Circles = styled.div`

--- a/src/components/ParkView/Components/VirtualGarden/Container.tsx
+++ b/src/components/ParkView/Components/VirtualGarden/Container.tsx
@@ -65,7 +65,10 @@ export const VirtualContainer = <T extends unknown>(): JSX.Element | null => {
         <Container>
             <FilterSelector />
             <ExpandProvider initialWidths={widths}>
-                <VirtualGarden garden={garden} />
+                <VirtualGarden
+                    garden={garden}
+                    width={itemWidth && itemWidth(garden, gardenKey.toString())}
+                />
             </ExpandProvider>
         </Container>
     );

--- a/src/components/ParkView/Components/VirtualGarden/GardenItemContainer.tsx
+++ b/src/components/ParkView/Components/VirtualGarden/GardenItemContainer.tsx
@@ -21,6 +21,7 @@ type PackageContainerProps<T> = {
     packageChild: React.MemoExoticComponent<(args: CustomItemView<T>) => JSX.Element> | undefined;
     handleExpand: any;
     items: GardenItem<T>[] | null;
+    itemWidth?: number;
 };
 export const GardenItemContainer = <T extends unknown>(props: PackageContainerProps<T>) => {
     const {
@@ -31,6 +32,7 @@ export const GardenItemContainer = <T extends unknown>(props: PackageContainerPr
         itemKey,
         handleExpand,
         items,
+        itemWidth,
     } = props;
     const expand = useExpand();
     const { onSelect } = useParkViewContext();
@@ -69,6 +71,7 @@ export const GardenItemContainer = <T extends unknown>(props: PackageContainerPr
                                     expand?.expandedColumns?.[garden[virtualColumn.index].value]
                                         ?.isExpanded ?? false
                                 }
+                                width={itemWidth}
                             />
                         ) : (
                             <DefaultPackage onClick={() => onSelect(item)}>

--- a/src/components/ParkView/Components/VirtualGarden/VirtualGarden.tsx
+++ b/src/components/ParkView/Components/VirtualGarden/VirtualGarden.tsx
@@ -13,10 +13,12 @@ import { getGardenItems, getRowCount } from './utils';
 
 type VirtualGardenProps<T> = {
     garden: GardenGroups<T>;
+    width?: number;
 };
 
 export const VirtualGarden = <T extends unknown>({
     garden,
+    width,
 }: VirtualGardenProps<T>): JSX.Element => {
     const parentRef = useRef<HTMLDivElement | null>(null);
 
@@ -114,6 +116,7 @@ export const VirtualGarden = <T extends unknown>({
                             packageChild={packageChild}
                             handleExpand={handleExpand}
                             items={columnItems}
+                            itemWidth={width}
                         />
                     </Fragment>
                 );

--- a/src/components/ParkView/Models/gardenOptions.ts
+++ b/src/components/ParkView/Models/gardenOptions.ts
@@ -18,6 +18,7 @@ export interface CustomItemView<T> {
     itemKey: string;
     onClick: () => void;
     columnExpanded: boolean;
+    width?: number;
 }
 
 export interface CustomGroupView<T> {


### PR DESCRIPTION
# Description

Add itemwidth prop to calculate item width when column is expanded. The description now will appear after the item, and the item will have the same size after expanding column. 
Completes: AB#FILL_IN_YOUR_ISSUE_ID

## Checklist:

-   [ ] I have performed a self-review of my own code.
-   [ ] I have linked my DevOps task using the AB# tag.
-   [ ] My code is easy to read, and comments are added where needed.
-   [ ] My code is covered by tests.
