### PR TITLE
[Garden & Sidesheet & Workspace] - hotfix: default value of customgroupbykeys 

### DIFF
--- a/src/Core/WorkSpace/src/WorkSpaceApi/workspaceApi.ts
+++ b/src/Core/WorkSpace/src/WorkSpaceApi/workspaceApi.ts
@@ -11,7 +11,7 @@ import {
     TreeOptions,
     WorkflowEditorOptions,
     WorkSpaceConfig,
-    WorkSpaceState
+    WorkSpaceState,
 } from './workspaceState';
 import {
     DataSource,
@@ -21,7 +21,7 @@ import {
     Validator,
     ViewerOptions,
     ViewOptions,
-    WorkSpaceApi
+    WorkSpaceApi,
 } from './WorkSpaceTypes';
 
 /**
@@ -137,7 +137,12 @@ export function createWorkSpace<T>(options: ViewerOptions<T>): WorkSpaceApi<T> {
 
         registerGardenOptions<T>(gardenOptions: Omit<GardenOptions<T>, 'onSelect'>) {
             updateState({
-                gardenOptions: { ...gardenOptions, onSelect } as GardenOptions<unknown>,
+                gardenOptions: {
+                    //HACK if customGroupByKeys is undefined, it will break memoized variable in VGarden and cause rerender??
+                    customGroupByKeys: {},
+                    ...gardenOptions,
+                    onSelect,
+                } as GardenOptions<unknown>,
             });
 
             return workspaceAPI;


### PR DESCRIPTION
When opening a sidesheet in a Garden, it will rerender and might cause a useLayoutEffect to trigger (scroll to highlighted column).
The code for it in VirtualGarden.tsx : 
```tsx
 const highlightedColumn = useMemo(
        () =>
            highlightColumn ? highlightColumn(gardenKey.toString(), customGroupByKeys) : undefined,
        [highlightColumn, gardenKey, customGroupByKeys]
    );
    useLayoutEffect(() => {
        if (highlightedColumn) {
            const scrollIndex = sortedColumns.findIndex(
                (column) => column.value === highlightedColumn
            );
            scrollIndex !== -1 && columnVirtualizer.scrollToIndex(scrollIndex, { align: 'center' });
        }
    }, [sortedColumns, columnVirtualizer.scrollToIndex, highlightedColumn]);
```

Inside app config we can declare customGroupByKeys (e.g. Handover config), or not (e.g. SWCR & Workorder). 
If customGroupByKeys is __NOT__ declared, this code above will trigger every time we open, close, resize a sidesheet, if it is declared, it will work as intended.


???

