### PR TITLE
[Piping & HT] - fix: remove double slash from api url

### DIFF
--- a/src/apps/DisciplineReleaseControl/DisciplineReleaseControlApp.tsx
+++ b/src/apps/DisciplineReleaseControl/DisciplineReleaseControlApp.tsx
@@ -10,7 +10,7 @@ import { filterConfig, tableConfig, gardenConfig, presetConfig } from './Workspa
 export function setup({ createWorkSpace }: ClientApi): void {
     const responseAsync = async (signal?: AbortSignal): Promise<Response> => {
         const { FAM } = httpClient();
-        return await FAM.fetch(`/v0.1/procosys/pipetest/JCA`, { signal: signal });
+        return await FAM.fetch(`v0.1/procosys/pipetest/JCA`, { signal: signal });
     };
 
     const responseParser = async (response: Response) => {


### PR DESCRIPTION
# Description

fam url from config:
 "FAM": "https://fam-api-prod.azurewebsites.net/",

Completes: AB#FILL_IN_YOUR_ISSUE_ID

## Checklist:

-   [ ] I have performed a self-review of my own code.
-   [ ] I have linked my DevOps task using the AB# tag.
-   [ ] My code is easy to read, and comments are added where needed.
-   [ ] My code is covered by tests.
