### PR TITLE
[PowerBI] - fix: sort filtergroups when state is set

### DIFF
--- a/src/modules/powerBI/src/Components/Filter/FilterGroup/FilterGroup.tsx
+++ b/src/modules/powerBI/src/Components/Filter/FilterGroup/FilterGroup.tsx
@@ -1,6 +1,7 @@
 import { Checkbox } from '@equinor/eds-core-react';
-import React, { useState } from 'react';
+import React, { useMemo, useState } from 'react';
 import { PowerBiFilter } from '../../../Types';
+import { searchFilterItems } from '../FilterItems/searchFilterItems';
 import { Header } from '../Header';
 import { searchSlicerFilters } from './searchSlicerFilters';
 import { CheckboxItem, CheckboxWrap, Container, FilterGroupContainer } from './Styles';
@@ -20,7 +21,10 @@ export const FilterGroup = ({
         const value = event.target.value;
         setFilterSearchValue(value);
     };
-
+    const searchedFilterGroups = useMemo(
+        () => searchSlicerFilters(slicerFilters, filterSearchValue),
+        [slicerFilters, filterSearchValue]
+    );
     //TODO: Check prefix on filter.type to see if it should render or not
     return (
         <Container>
@@ -28,24 +32,22 @@ export const FilterGroup = ({
 
             <FilterGroupContainer>
                 <CheckboxWrap>
-                    {searchSlicerFilters(slicerFilters, filterSearchValue)
-                        .sort((a, b) => a.type.localeCompare(b.type))
-                        .map((filter: PowerBiFilter) => {
-                            return (
-                                <CheckboxItem key={filter.type}>
-                                    <Checkbox
-                                        onChange={async () => {
-                                            await handleChangeGroup(filter);
-                                        }}
-                                        checked={
-                                            filterGroupVisible?.find((a) => a === filter.type) !==
-                                            undefined
-                                        }
-                                    />
-                                    <label>{filter.type}</label>
-                                </CheckboxItem>
-                            );
-                        })}
+                    {searchedFilterGroups.map((filter: PowerBiFilter) => {
+                        return (
+                            <CheckboxItem key={filter.type}>
+                                <Checkbox
+                                    onChange={async () => {
+                                        await handleChangeGroup(filter);
+                                    }}
+                                    checked={
+                                        filterGroupVisible?.find((a) => a === filter.type) !==
+                                        undefined
+                                    }
+                                />
+                                <label>{filter.type}</label>
+                            </CheckboxItem>
+                        );
+                    })}
                 </CheckboxWrap>
             </FilterGroupContainer>
         </Container>

--- a/src/modules/powerBI/src/Components/Filter/PowerBIFilter.tsx
+++ b/src/modules/powerBI/src/Components/Filter/PowerBIFilter.tsx
@@ -175,7 +175,7 @@ export const PowerBIFilter = ({
             (async () => {
                 const filters = await getFilters(report);
                 const defaultActiveFilters = await getActiveFilterValues(filters);
-                setSlicerFilters(filters);
+                setSlicerFilters(filters.sort((a, b) => a.type.localeCompare(b.type)));
                 setActiveFilters(defaultActiveFilters);
             })();
         }
@@ -190,7 +190,7 @@ export const PowerBIFilter = ({
         if (report && isLoaded) {
             (async () => {
                 const filters = await getFilters(report);
-                setSlicerFilters(filters);
+                setSlicerFilters(filters.sort((a, b) => a.type.localeCompare(b.type)));
                 const filterGroupNames = getActiveFilterGroupArray(activeFilters);
                 setFilterGroupVisible((s) => [...s, ...filterGroupNames]);
             })();


### PR DESCRIPTION
# Description
Bug: When I set an active filter, the whole filter will rerender and scroll me back to the top.

Completes: AB#FILL_IN_YOUR_ISSUE_ID

## Checklist:

-   [ ] I have performed a self-review of my own code.
-   [ ] I have linked my DevOps task using the AB# tag.
-   [ ] My code is easy to read, and comments are added where needed.
-   [ ] My code is covered by tests.
