### PR TITLE
[Table] - chore: remove aggregated when grouping

### DIFF
--- a/src/packages/Table/Components/Table.tsx
+++ b/src/packages/Table/Components/Table.tsx
@@ -179,9 +179,7 @@ const RenderRow = ({ data, index, style }: RenderRowProps): JSX.Element | null =
                             {cell.isGrouped ? (
                                 <GroupCell row={row} cell={cell} />
                             ) : cell.isAggregated &&
-                              cell.value ? // If the cell is aggregated, use the Aggregated
-                            // renderer for cell
-                            null : cell.isPlaceholder ? null : (
+                              cell.value ? null : cell.isPlaceholder ? null : ( // If the cell is aggregated, blank field expect the grouped one
                                 // For cells with repeated values, render null
                                 // Otherwise, just render the regular cell
                                 cell.render('Cell')

--- a/src/packages/Table/Components/Table.tsx
+++ b/src/packages/Table/Components/Table.tsx
@@ -178,11 +178,10 @@ const RenderRow = ({ data, index, style }: RenderRowProps): JSX.Element | null =
                         <span style={{ fontSize: '14px', width: '100%' }}>
                             {cell.isGrouped ? (
                                 <GroupCell row={row} cell={cell} />
-                            ) : cell.isAggregated && cell.value ? (
-                                // If the cell is aggregated, use the Aggregated
-                                // renderer for cell
-                                cell.render('Aggregated')
-                            ) : cell.isPlaceholder ? null : (
+                            ) : cell.isAggregated &&
+                              cell.value ? // If the cell is aggregated, use the Aggregated
+                            // renderer for cell
+                            null : cell.isPlaceholder ? null : (
                                 // For cells with repeated values, render null
                                 // Otherwise, just render the regular cell
                                 cell.render('Cell')


### PR DESCRIPTION
# Description

Request to blank out all other aggregated fields fields when something is grouped:
![image](https://user-images.githubusercontent.com/28650210/171112399-bbdf99d6-1444-4527-9f43-7f9fdddb4ca8.png)


Completes: AB#FILL_IN_YOUR_ISSUE_ID

## Checklist:

-   [ ] I have performed a self-review of my own code.
-   [ ] I have linked my DevOps task using the AB# tag.
-   [ ] My code is easy to read, and comments are added where needed.
-   [ ] My code is covered by tests.
