### PR TITLE
[Portal] Fix reference error hmr vite

### DIFF
--- a/src/apps/DisciplineReleaseControl/Components/Sidesheet/ReleaseControlSidesheet.tsx
+++ b/src/apps/DisciplineReleaseControl/Components/Sidesheet/ReleaseControlSidesheet.tsx
@@ -41,10 +41,10 @@ interface ReleaseControlSidesheetProps {
     actions: SidesheetApi;
 }
 
-export const ReleaseControlSidesheet = ({
+export function ReleaseControlSidesheet({
     actions,
     item,
-}: ReleaseControlSidesheetProps): JSX.Element => {
+}: ReleaseControlSidesheetProps): JSX.Element {
     const [errorMessage] = useState<ServerError | undefined>();
 
     const [activeTab, setActiveTab] = useState<number>(0);
@@ -148,4 +148,4 @@ export const ReleaseControlSidesheet = ({
             </Tabs>
         </Wrapper>
     );
-};
+}


### PR DESCRIPTION
# Description
Will fix this specific scenario Uncaught ReferenceError: Cannot access 'ReleaseControlSidesheet' before initialization
    at ReleaseControlApp.tsx:11:16
Please include a summary of the change and which issue is fixed.
List any external dependencies that are required for this change.

Completes: AB#FILL_IN_YOUR_ISSUE_ID

## Checklist:

-   [ ] I have performed a self-review of my own code.
-   [ ] I have linked my DevOps task using the AB# tag.
-   [ ] My code is easy to read, and comments are added where needed.
-   [ ] My code is covered by tests.
