### PR TITLE
[GardenUtils & SWCR & MC & Handover & DRC]- fix: date utils

### DIFF
--- a/src/apps/DisciplineReleaseControl/Functions/statusHelpers.ts
+++ b/src/apps/DisciplineReleaseControl/Functions/statusHelpers.ts
@@ -513,8 +513,8 @@ export function getPipetestStatusForStep(checkLists: CheckList[]): string {
 
 export const getYearAndWeekFromDate = (date: Date): string => {
     const dateTime = DateTime.local(date.getFullYear(), date.getMonth() + 1, date.getDate());
-    if (dateTime.weekYear === 1) return DATE_BLANKSTRING;
-    return `${dateTime.weekYear}-${dateTime.weekNumber}`;
+    if (dateTime.year === 1) return DATE_BLANKSTRING;
+    return `${dateTime.year}-${dateTime.weekNumber}`;
 };
 
 export const DATE_BLANKSTRING = 'No Date';

--- a/src/apps/Handover/Garden/utility/getKeyFunctions.ts
+++ b/src/apps/Handover/Garden/utility/getKeyFunctions.ts
@@ -46,12 +46,12 @@ export const getYearAndWeekAndDayFromString = (dateString: string) => {
     const date = new Date(dateString);
     const dateTime = DateTime.fromJSDate(date);
     if (!dateTime.isValid) return 'N/A';
-    return `${dateTime.weekYear}-${dateTime.month}-${dateTime.weekday}`;
+    return `${dateTime.year}-${dateTime.month}-${dateTime.weekday}`;
 };
 
 export const getYearAndWeekFromDate = (date: Date): string => {
     const dateTime = DateTime.fromJSDate(date);
-    return `${dateTime.weekYear}-${dateTime.weekNumber}`;
+    return `${dateTime.year}-${dateTime.weekNumber}`;
 };
 
 export const getYearAndWeekFromString = (dateString: string): string => {

--- a/src/apps/Handover/Garden/utility/getKeyFunctions.ts
+++ b/src/apps/Handover/Garden/utility/getKeyFunctions.ts
@@ -46,7 +46,7 @@ export const getYearAndWeekAndDayFromString = (dateString: string) => {
     const date = new Date(dateString);
     const dateTime = DateTime.fromJSDate(date);
     if (!dateTime.isValid) return 'N/A';
-    return `${dateTime.year}-${dateTime.month}-${dateTime.weekday}`;
+    return `${dateTime.year}-${dateTime.month}-${dateTime.day}`;
 };
 
 export const getYearAndWeekFromDate = (date: Date): string => {

--- a/src/apps/MechanicalCompletion/utils/helpers/getHighlightedColumn.ts
+++ b/src/apps/MechanicalCompletion/utils/helpers/getHighlightedColumn.ts
@@ -1,4 +1,4 @@
-import { getYearAndWeekFromDate } from '@equinor/GardenUtils';
+import { getYearAndWeekAndDayFromString, getYearAndWeekFromDate } from '@equinor/GardenUtils';
 import { CustomGroupByKeys } from '../../types';
 
 export const getHighlightedColumn = (
@@ -13,7 +13,9 @@ export const getHighlightedColumn = (
         groupByKey === 'rfcc' ||
         groupByKey === 'punchAccepted'
     ) {
-        return weeklyDaily === 'Daily' ? new Date().toString() : getYearAndWeekFromDate(new Date());
+        return weeklyDaily === 'Daily'
+            ? getYearAndWeekAndDayFromString(new Date().toString())
+            : getYearAndWeekFromDate(new Date());
     } else {
         return undefined;
     }

--- a/src/apps/swcr/utilities/packages.ts
+++ b/src/apps/swcr/utilities/packages.ts
@@ -70,7 +70,7 @@ export const getHoursGroupKey: GetKeyFunction<SwcrPackage> = (item) => {
 export const getYearAndWeekFromDate = (date: Date): string => {
     const dateTime = DateTime.local(date.getFullYear(), date.getMonth() + 1, date.getDate());
     const weekNumber = dateTime.weekNumber < 10 ? `0${dateTime.weekNumber}` : dateTime.weekNumber;
-    return `${dateTime.weekYear}-${weekNumber}`;
+    return `${dateTime.year}-${weekNumber}`;
 };
 
 export const getYearAndWeekFromString = (dateString: string, removeDays = 0): string => {

--- a/src/packages/GardenUtils/src/dateUtils.ts
+++ b/src/packages/GardenUtils/src/dateUtils.ts
@@ -2,7 +2,7 @@ import { DateTime } from 'luxon';
 
 export const getYearAndWeekFromDate = (date: Date): string => {
     const dateTime = DateTime.local(date.getFullYear(), date.getMonth() + 1, date.getDate());
-    return `${dateTime.weekYear}-${
+    return `${dateTime.year}-${
         dateTime.weekNumber < 10 ? '0' + dateTime.weekNumber : dateTime.weekNumber
     }`;
 };
@@ -22,5 +22,5 @@ export const getYearAndWeekAndDayFromString = (dateString: string) => {
     const date = new Date(dateString);
     const dateTime = DateTime.fromJSDate(date);
     if (!dateTime.isValid) return 'N/A';
-    return `${dateTime.weekYear}-${dateTime.month}-${dateTime.weekday}`;
+    return `${dateTime.year}-${dateTime.month}-${dateTime.day}`;
 };


### PR DESCRIPTION
# Description

WeekYear yields: DateTime.local(2014, 12, 31).weekYear //=> 2015
year yields: DateTime.local(2017, 5, 25).year //=> 2017

## Checklist:

-   [ ] I have performed a self-review of my own code.
-   [ ] I have linked my DevOps task using the AB# tag.
-   [ ] My code is easy to read, and comments are added where needed.
-   [ ] My code is covered by tests.
