### PR TITLE
[Workspace & PowerBIViewer] - Fix/pbi sidesheet bookmark subpage

### DIFF
--- a/src/Core/PowerBiViewer/src/Context/PbiContext.tsx
+++ b/src/Core/PowerBiViewer/src/Context/PbiContext.tsx
@@ -90,13 +90,9 @@ export const PowerBiViewerContext = ({ children }: PropsWithChildren<{}>) => {
                 setReady(false);
                 setState((s) => ({
                     ...s,
-                    activePage: {
-                        pageId: bookmark?.mainPage || bookmark.name,
-                        pageTitle: bookmark?.mainPageDisplayName || bookmark.displayName,
-                    },
                     pbiOptions: {
                         bookmark: { state: bookmark.bookmarkState },
-                        defaultPage: bookmark?.mainPage || bookmark.name,
+                        defaultPage: bookmark?.name || bookmark.name,
                     },
                 }));
 

--- a/src/Core/PowerBiViewer/src/Context/PbiContext.tsx
+++ b/src/Core/PowerBiViewer/src/Context/PbiContext.tsx
@@ -92,7 +92,7 @@ export const PowerBiViewerContext = ({ children }: PropsWithChildren<{}>) => {
                     ...s,
                     pbiOptions: {
                         bookmark: { state: bookmark.bookmarkState },
-                        defaultPage: bookmark?.name || bookmark.name,
+                        defaultPage: bookmark?.name || bookmark.mainPage,
                     },
                 }));
 

--- a/src/Core/PowerBiViewer/src/PowerBiViewer.tsx
+++ b/src/Core/PowerBiViewer/src/PowerBiViewer.tsx
@@ -43,7 +43,7 @@ const PbiViewer = (props: PowerBiViewerProps) => {
                     options={{
                         ...pbiOptions,
                         activePage: activePage?.pageId,
-                        defaultPage: activePage?.pageId,
+                        defaultPage: pbiOptions?.defaultPage || activePage?.pageId,
                         bookmark: pbiOptions?.bookmark,
                         activePageDisplayName: activePage?.pageTitle,
                         applyBookmark: handleApplyingBookmark,

--- a/src/Core/WorkSpace/src/Components/DataViewerHeader/PowerBIPages/PowerBIPages.tsx
+++ b/src/Core/WorkSpace/src/Components/DataViewerHeader/PowerBIPages/PowerBIPages.tsx
@@ -14,9 +14,8 @@ export const PowerBiPages = (): JSX.Element => {
                         <TabButton
                             width={`${page.displayName.length * 10}px`}
                             aria-selected={
-                                (activePage?.pageId &&
-                                    page.name === activePage.pageId &&
-                                    page.displayName === activePage.pageTitle) ||
+                                (activePage?.pageId && page.name === activePage.pageId) ||
+                                page.displayName === activePage?.pageTitle ||
                                 false
                             }
                             key={`pages-${page.name}`}

--- a/src/Core/WorkSpace/src/Context/BookmarkContext.tsx
+++ b/src/Core/WorkSpace/src/Context/BookmarkContext.tsx
@@ -61,7 +61,8 @@ export const BookmarkContextWrapper = ({
         if (activeTab !== 'analytics') {
             setActivePage(
                 {
-                    pageId: bookmark?.mainPage || bookmark.name,
+                    pageId:
+                        bookmark.name !== bookmark?.mainPage ? bookmark.name : bookmark.mainPage,
                     pageTitle: bookmark?.mainPageDisplayName || bookmark.displayName,
                 },
                 {
@@ -73,7 +74,7 @@ export const BookmarkContextWrapper = ({
             return;
         } else {
             setActivePage({
-                pageId: bookmark?.mainPage || bookmark.name,
+                pageId: bookmark.name !== bookmark?.mainPage ? bookmark.name : bookmark?.mainPage,
                 pageTitle: bookmark?.mainPageDisplayName || bookmark.displayName,
             });
             if (isRedirect) {

--- a/src/Core/WorkSpace/src/Context/BookmarkContext.tsx
+++ b/src/Core/WorkSpace/src/Context/BookmarkContext.tsx
@@ -61,8 +61,7 @@ export const BookmarkContextWrapper = ({
         if (activeTab !== 'analytics') {
             setActivePage(
                 {
-                    pageId:
-                        bookmark.name !== bookmark?.mainPage ? bookmark.name : bookmark.mainPage,
+                    pageId: bookmark.name,
                     pageTitle: bookmark?.mainPageDisplayName || bookmark.displayName,
                 },
                 {
@@ -74,7 +73,7 @@ export const BookmarkContextWrapper = ({
             return;
         } else {
             setActivePage({
-                pageId: bookmark.name !== bookmark?.mainPage ? bookmark.name : bookmark?.mainPage,
+                pageId: bookmark.name,
                 pageTitle: bookmark?.mainPageDisplayName || bookmark.displayName,
             });
             if (isRedirect) {


### PR DESCRIPTION
# Description

Fixes for edge cases with page navigation in power bi together with bookmarks. If you have saved a bookmark within a subpage, the page ID will differ from the external page ID (Page ID that is set in Workspace/PowerBIViewer). If these two differ, we want to use the internal page ID instead of the external one. 

Since the page IDs differ, we need another way to check if the page is active to get the correct styling. We check both page ID and page display name. Page display name for subpages should always be identical to the main page display name.

Completes: AB#FILL_IN_YOUR_ISSUE_ID

## Checklist:

-   [ ] I have performed a self-review of my own code.
-   [ ] I have linked my DevOps task using the AB# tag.
-   [ ] My code is easy to read, and comments are added where needed.
-   [ ] My code is covered by tests.
