### PR TITLE
[Workorder] - fix: add abortsignal to api calls

### DIFF
--- a/src/apps/WorkOrder/Garden/components/WorkOrderSidesheet/hooks/useMaterial.ts
+++ b/src/apps/WorkOrder/Garden/components/WorkOrderSidesheet/hooks/useMaterial.ts
@@ -8,8 +8,10 @@ export const useMaterial = (
 ): { material: WorkOrderMaterial[] | undefined; isFetching: boolean; error: Error | null } => {
     const { FAM } = useHttpClient();
 
-    const fetch = useCallback(async (id: string) => {
-        const response = await FAM.fetch(`v0.1/procosys/workorder/JCA/material/${id}`);
+    const fetch = useCallback(async (id: string, signal?: AbortSignal) => {
+        const response = await FAM.fetch(`v0.1/procosys/workorder/JCA/material/${id}`, {
+            signal,
+        });
 
         return JSON.parse(await response.text()) as WorkOrderMaterial[];
     }, []);

--- a/src/apps/WorkOrder/Garden/components/WorkOrderSidesheet/hooks/useMccr.ts
+++ b/src/apps/WorkOrder/Garden/components/WorkOrderSidesheet/hooks/useMccr.ts
@@ -8,8 +8,8 @@ export const useMccr = (
 ): { mccr: WorkOrderMccr[] | undefined; isFetching: boolean; error: Error | null } => {
     const { FAM } = useHttpClient();
 
-    const fetch = useCallback(async (id: string) => {
-        const response = await FAM.fetch(`v0.1/procosys/workorder/JCA/mccr/${id}`);
+    const fetch = useCallback(async (id: string, signal?: AbortSignal) => {
+        const response = await FAM.fetch(`v0.1/procosys/workorder/JCA/mccr/${id}`, { signal });
         return JSON.parse(await response.text()) as WorkOrderMccr[];
     }, []);
     const resource = usePackageResource('mccr', packageId || '', fetch);


### PR DESCRIPTION
# Description

Adding abortsignal to the sidesheet api calls so it cancels if sidesheet is closed/changed.

Completes: AB#FILL_IN_YOUR_ISSUE_ID

## Checklist:

-   [ ] I have performed a self-review of my own code.
-   [ ] I have linked my DevOps task using the AB# tag.
-   [ ] My code is easy to read, and comments are added where needed.
-   [ ] My code is covered by tests.
