### PR TITLE
[Menu] - fix: match match to find active app

### DIFF
--- a/src/components/Menu/Components/MenuItem/MenuItem.tsx
+++ b/src/components/Menu/Components/MenuItem/MenuItem.tsx
@@ -1,6 +1,6 @@
 import { isAppActive, isProduction } from '@equinor/lighthouse-portal-client';
 import { useMemo, useState } from 'react';
-import { useNavigate } from 'react-router-dom';
+import { matchPath, useLocation, useNavigate } from 'react-router-dom';
 import { AppManifest } from '../../../../Core/Client/Types';
 import Icon from '../../../Icon/Icon';
 import { useFavoritesContext } from '../../Context/FavoritesContext';
@@ -15,17 +15,21 @@ interface MenuItemProps {
 }
 
 export const MenuItem = ({ manifest, groupId, onClick }: MenuItemProps): JSX.Element | null => {
-    const { toggleFavorite, hasFavorite } = useFavoritesContext();
-    const navigate = useNavigate();
     const [showIcon, setShowIcon] = useState(false);
+    const { toggleFavorite, hasFavorite } = useFavoritesContext();
+
+    const navigate = useNavigate();
+    const { pathname } = useLocation();
+
     const isActive = useMemo(() => isAppActive(manifest), [manifest]);
 
+    const activePath = matchPath(`/${groupId}/${manifest.shortName}/*`, pathname);
     if (!isActive) return null;
 
     return (
         <Item
             isLink={manifest.uri !== undefined}
-            active={location.pathname.includes(`${groupId}/${manifest.shortName}`)}
+            active={activePath !== null}
             title={isActive ? manifest.title : 'Disabled'}
             onClick={(e) => {
                 e.preventDefault();


### PR DESCRIPTION
# Description

There is a bug if you have multiple apps with similar short names and groups

```ts
const pathname = "/ConstructionAndCommissioning/preservation-analytics"
const pathname2 = "/ConstructionAndCommssioning/preservation"

const shortname = "preservation-analytics";
const shortname2 = "preservation";

console.log("Does it equal?", pathname.includes(shortname2)) // logs true
```
ìncludes` is not good enough for this case, so instead we can use react-router's matchPath function.
Completes: [AB#251814](https://dev.azure.com/Equinor/fa63ceea-8883-41e2-8823-a3b54e4be178/_workitems/edit/251814)

## Checklist:

-   [x] I have performed a self-review of my own code.
-   [x] I have linked my DevOps task using the AB# tag.
-   [x] My code is easy to read, and comments are added where needed.
-   [ ] My code is covered by tests.
