### PR TITLE
[Garden] - hotfix: force a recalc of row count when subgroups are toggled

### DIFF
--- a/src/components/ParkView/Components/VirtualGarden/VirtualGarden.tsx
+++ b/src/components/ParkView/Components/VirtualGarden/VirtualGarden.tsx
@@ -15,7 +15,6 @@ type VirtualGardenProps<T extends Record<PropertyKey, unknown>> = {
     width?: number;
     selectedItem: string | null;
     handleOnItemClick: (item: T) => void;
-    setGarden: (garden: DataSet<T>[]) => void;
 };
 
 export const VirtualGarden = <T extends Record<PropertyKey, unknown>>({


### PR DESCRIPTION
# Description

Please include a summary of the change and which issue is fixed.
List any external dependencies that are required for this change.

Completes: [AB#265764](https://dev.azure.com/Equinor/fa63ceea-8883-41e2-8823-a3b54e4be178/_workitems/edit/265764)
Completes: [AB#259920](https://dev.azure.com/Equinor/fa63ceea-8883-41e2-8823-a3b54e4be178/_workitems/edit/259920)
## Checklist:

-   [x] I have performed a self-review of my own code.
-   [x] I have linked my DevOps task using the AB# tag.
-   [x] My code is easy to read, and comments are added where needed.
-   [ ] My code is covered by tests.
