### PR TITLE
[Table] - fix: early return on row click if row is grouped

### DIFF
--- a/src/packages/Table/Components/Table.tsx
+++ b/src/packages/Table/Components/Table.tsx
@@ -155,6 +155,9 @@ const RenderRow = ({ data, index, style }: RenderRowProps): JSX.Element | null =
     // eslint-disable-next-line react-hooks/rules-of-hooks
     const handleClick = useCallback(() => {
         //data.setSelected && data.setSelected(row.original);
+        if (row.isGrouped) {
+            return;
+        }
         data?.onSelect && data.onSelect(row.original, row.id);
         // eslint-disable-next-line react-hooks/exhaustive-deps
     }, [data?.onSelect, row]);


### PR DESCRIPTION
# Description
When grouping a column in Table view, and a user clicks on the grouped rows, a sidesheet will appear and fail. Added an early return if the row the user is trying to click on is a grouped row.

Completes: [AB#263483](https://dev.azure.com/Equinor/fa63ceea-8883-41e2-8823-a3b54e4be178/_workitems/edit/263483)

## Checklist:

-   [x] I have performed a self-review of my own code.
-   [x] I have linked my DevOps task using the AB# tag.
-   [x] My code is easy to read, and comments are added where needed.
-   [ ] My code is covered by tests.
