### PR TITLE
hotfix: remove tagmountedon property, deprecated

### DIFF
--- a/src/apps/ReleaseControl/types/releaseControl.ts
+++ b/src/apps/ReleaseControl/types/releaseControl.ts
@@ -186,7 +186,6 @@ export type FamTag = {
     installedCableLength: string | null;
     estimatedCableLength: string | null;
     tagHeated: string | null;
-    tagMountedOn: string | null;
     switchBoardTagNos: string | null;
     circuitTagNos: string | null;
 
@@ -217,7 +216,6 @@ export type FamTagType = {
     installedCableLength: string | null;
     estimatedCableLength: string | null;
     tagHeated: string | null;
-    tagMountedOn: string | null;
     switchBoardTagNos: string | null;
     circuitTagNos: string | null;
 

--- a/src/apps/ScopeChangeRequest/api/FAM/searchHtCable.ts
+++ b/src/apps/ScopeChangeRequest/api/FAM/searchHtCable.ts
@@ -25,7 +25,6 @@ export async function searchHtCable(value: string): Promise<any[]> {
             'InstalledCableLength',
             'MountedOn',
             'TagHeated',
-            'TagMountedOn',
             'EstimatedCableLength',
             'SwitchBoardTagNos',
             'CircuitTagNos',

--- a/src/apps/ScopeChangeRequest/api/FAM/searchTag.ts
+++ b/src/apps/ScopeChangeRequest/api/FAM/searchTag.ts
@@ -25,7 +25,6 @@ export async function searchTag(value: string): Promise<any[]> {
             'InstalledCableLength',
             'MountedOn',
             'RelatedHTCables',
-            'TagMountedOn',
             'EstimatedCableLength',
         ],
         'And',


### PR DESCRIPTION
# Description

TagMountedOn has been deprecated. Removed from API calls to FAM and also the interface.


## Checklist:

-   [x] I have performed a self-review of my own code.
-   [ ] I have linked my DevOps task using the AB# tag.
-   [x] My code is easy to read, and comments are added where needed.
-   [ ] My code is covered by tests.
