### PR TITLE
[Utils] - feat: use click outside hook

### DIFF
--- a/src/packages/Utils/Hooks/index.ts
+++ b/src/packages/Utils/Hooks/index.ts
@@ -2,4 +2,4 @@ export * from './useCancellation';
 export * from './useElementData';
 export * from './useEventListener';
 export * from './useIsMounted';
-
+export * from './useClickOutside';

--- a/src/packages/Utils/Hooks/useClickOutside.ts
+++ b/src/packages/Utils/Hooks/useClickOutside.ts
@@ -1,0 +1,27 @@
+import { MutableRefObject, useEffect } from 'react';
+/**
+ * Hook to detect `mouseup` and `touchstart` events on DOM elements not part of the `ref` argument
+ * @param ref The DOM element to watch for clicks outside of
+ * @param handler Function that is fired off when clicks outside of the DOM element are detected. Wrap in useCallback.
+ */
+export const useClickOutside = (
+    ref: MutableRefObject<HTMLElement | null>,
+    handler: (evt: Event) => void
+): void => {
+    useEffect(() => {
+        const listener = (evt: Event) => {
+            if (!ref.current || ref.current.contains(evt.target as Node)) {
+                return;
+            }
+            handler(evt);
+        };
+
+        document.addEventListener('mouseup', listener);
+        document.addEventListener('touchstart', listener);
+
+        return () => {
+            document.removeEventListener('mouseup', listener);
+            document.removeEventListener('touchstart', listener);
+        };
+    }, [ref, handler]);
+};


### PR DESCRIPTION
# Description

Hook to detect clicks outside on a certain DOM element and fires off a handler.

Completes: AB#FILL_IN_YOUR_ISSUE_ID

## Checklist:

-   [ ] I have performed a self-review of my own code.
-   [ ] I have linked my DevOps task using the AB# tag.
-   [ ] My code is easy to read, and comments are added where needed.
-   [ ] My code is covered by tests.
