### PR TITLE
[PowerBI] - fix: close filter search when click outside

### DIFF
--- a/src/modules/powerBI/src/Components/Filter/ExpandedFilter/ExpandedFilter.tsx
+++ b/src/modules/powerBI/src/Components/Filter/ExpandedFilter/ExpandedFilter.tsx
@@ -6,6 +6,7 @@ import { FilterClearIcon } from '../FilterClearIcon';
 import { FilterItems } from './FilterItems';
 import { ExpandedFilterWrapper, FilterItemsWrapper, Sidebar } from '../Styles';
 import { FilterController } from '../types';
+import { FilterItemsProvider } from './FilterItems/FilterItemsProvider';
 
 interface ExpandedFilterProps {
     controller: FilterController;
@@ -28,14 +29,15 @@ export function ExpandedFilter({ controller }: ExpandedFilterProps): JSX.Element
         <ExpandedFilterWrapper>
             <FilterItemsWrapper>
                 {visibleFilters.map((groupName) => (
-                    <FilterItems
-                        controller={controller}
-                        handleOnChange={handleOnChange}
-                        handleOnSelectAll={controller.handleOnSelectAll}
-                        activeFilters={activeFilters}
-                        group={slicerFilters.find((s) => s.type === groupName) as PowerBiFilter}
-                        key={groupName}
-                    />
+                    <FilterItemsProvider key={groupName}>
+                        <FilterItems
+                            controller={controller}
+                            handleOnChange={handleOnChange}
+                            handleOnSelectAll={controller.handleOnSelectAll}
+                            activeFilters={activeFilters}
+                            group={slicerFilters.find((s) => s.type === groupName) as PowerBiFilter}
+                        />
+                    </FilterItemsProvider>
                 ))}
             </FilterItemsWrapper>
             <Sidebar>

--- a/src/modules/powerBI/src/Components/Filter/ExpandedFilter/FilterItems/FilterItemsProvider.tsx
+++ b/src/modules/powerBI/src/Components/Filter/ExpandedFilter/FilterItems/FilterItemsProvider.tsx
@@ -1,0 +1,16 @@
+import { createRefContext } from '@equinor/lighthouse-utils';
+import { ReactNode } from 'react';
+
+type FilterItemsContext = {
+    isSearchActive: boolean;
+    searchValue: string;
+};
+const context = createRefContext<FilterItemsContext>({
+    isSearchActive: false,
+    searchValue: '',
+});
+
+export const { useStore } = context;
+export const FilterItemsProvider = ({ children }: { children: ReactNode }): JSX.Element => {
+    return <context.Provider>{children}</context.Provider>;
+};

--- a/src/modules/powerBI/src/Components/Filter/ExpandedFilter/FilterItems/Header/Header.tsx
+++ b/src/modules/powerBI/src/Components/Filter/ExpandedFilter/FilterItems/Header/Header.tsx
@@ -1,29 +1,46 @@
 import { Icon, Search } from '@equinor/eds-core-react';
 import { Case, Switch } from '@equinor/JSX-Switch';
-import { useState } from 'react';
+import { ChangeEvent, useCallback } from 'react';
 import { FilterClearIcon } from '../../../FilterClearIcon';
+import { useStore } from '../FilterItemsProvider';
 import { Container, SearchButton, Title } from './Styles';
 
 type HeaderProps = {
     title: string;
-    onSearch: (value: string | undefined) => void;
     searchEnabled: boolean;
     handleEnterPress: () => void;
     deselectAllValues: () => Promise<void>;
     hasActiveFilters: boolean;
-    searchValue: string | undefined;
 };
 
 export const Header = ({
     title,
-    onSearch,
     searchEnabled,
     handleEnterPress,
-    searchValue,
     hasActiveFilters,
     deselectAllValues,
 }: HeaderProps): JSX.Element => {
-    const [isSearchActive, setIsSearchActive] = useState<boolean>(false);
+    const [searchValue, setSearchValue] = useStore((store) => store.searchValue);
+    const [isSearchActive, setIsSearchActive] = useStore((store) => store.isSearchActive);
+
+    const handleSearchChange = useCallback(
+        (e: ChangeEvent<HTMLInputElement>) => {
+            setSearchValue({ searchValue: e.target.value });
+        },
+        [setSearchValue]
+    );
+
+    const handleOnTitleClick = () => {
+        searchEnabled && setIsSearchActive({ isSearchActive: true });
+    };
+
+    const handleOnSearchButtonClick = () => {
+        setIsSearchActive({ isSearchActive: !isSearchActive });
+    };
+
+    const handleKeyPress = (e: React.KeyboardEvent<HTMLInputElement>) => {
+        e.key === 'Enter' && handleEnterPress();
+    };
     return (
         <Container>
             <Switch>
@@ -34,26 +51,16 @@ export const Header = ({
                         placeholder="Search"
                         value={searchValue}
                         aria-label="filter group"
-                        onKeyPress={(e) => e.key === 'Enter' && handleEnterPress()}
-                        onChange={(e) => onSearch(e.target.value)}
-                        onBlur={() => {
-                            setIsSearchActive(false);
-                            onSearch(undefined);
-                        }}
+                        onKeyPress={handleKeyPress}
+                        onChange={handleSearchChange}
                     />
                 </Case>
                 <Case when={true}>
-                    <Title
-                        onClick={() => searchEnabled && setIsSearchActive(true)}
-                        hasActiveFilters={hasActiveFilters}
-                    >
+                    <Title onClick={handleOnTitleClick} hasActiveFilters={hasActiveFilters}>
                         {title}
                     </Title>
                     {searchEnabled && (
-                        <SearchButton
-                            onClick={() => setIsSearchActive((s) => !s)}
-                            variant={'ghost_icon'}
-                        >
+                        <SearchButton onClick={handleOnSearchButtonClick} variant={'ghost_icon'}>
                             <Icon id="search" name="search" />
                         </SearchButton>
                     )}


### PR DESCRIPTION
# Description

Using the hook `useClickOutside` to detect clicks outside of each FilterGroup component. Added some states in a context instead of prop drilling.
Refactored some "handle" functions.

Completes: AB#269856

## Checklist:

-   [ ] I have performed a self-review of my own code.
-   [ ] I have linked my DevOps task using the AB# tag.
-   [ ] My code is easy to read, and comments are added where needed.
-   [ ] My code is covered by tests.
