### PR TITLE
[PBI] - fix: pbi filter overflowing

### DIFF
--- a/src/modules/powerBI/src/Components/Filter/ExpandedFilter/FilterItems/Header/Header.tsx
+++ b/src/modules/powerBI/src/Components/Filter/ExpandedFilter/FilterItems/Header/Header.tsx
@@ -30,6 +30,9 @@ export const Header = ({
                 <Case when={isSearchActive}>
                     <Search
                         autoFocus={isSearchActive}
+                        style={{
+                            width: '150px',
+                        }}
                         id="search-normal"
                         placeholder="Search"
                         value={searchValue}

--- a/src/modules/powerBI/src/Components/Filter/ExpandedFilter/FilterItems/Styles.tsx
+++ b/src/modules/powerBI/src/Components/Filter/ExpandedFilter/FilterItems/Styles.tsx
@@ -6,7 +6,6 @@ export const FilterGroupContainer = styled.div`
     flex-direction: column;
     margin: 0rem 0.5rem;
     height: -webkit-fill-available;
-    min-width: 150px;
 `;
 
 export const CheckboxWrap = styled.span`

--- a/src/modules/powerBI/src/Components/Filter/Styles.tsx
+++ b/src/modules/powerBI/src/Components/Filter/Styles.tsx
@@ -20,7 +20,6 @@ export const FilterGroupWrap = styled.div`
 export const FilterItemsWrapper = styled.div`
     display: flex;
     flex-direction: row;
-    width: 100%;
     height: 100%;
     overflow-x: auto;
     overflow-y: hidden;
@@ -40,7 +39,8 @@ export const Item = styled(Button)`
 `;
 
 export const ExpandedFilterWrapper = styled.div`
-    display: flex;
+    display: grid;
+    grid-template-columns: 1fr auto;
     height: 250px;
     overflow: hidden;
     border-bottom: 1px solid ${tokens.colors.ui.background__medium.hex};


### PR DESCRIPTION
# Description

PBI filter will overflow wrongly when adding too many filter groups in "Advanced Filter". 
Virtualizing filter items in each group makes it a bit weird with widths. Replaced flexbox with grid, and removed min-width property. Set a pixel width on the SearchBox component because a filter group's width couldn't dynamically resize when opening the SearchBox.

Completes: AB#253853

## Checklist:

-   [ ] I have performed a self-review of my own code.
-   [ ] I have linked my DevOps task using the AB# tag.
-   [ ] My code is easy to read, and comments are added where needed.
-   [ ] My code is covered by tests.
