### PR TITLE
[PBI] - fix: clear searchvalue when closing searchbox

### DIFF
--- a/src/modules/powerBI/src/Components/Filter/ExpandedFilter/FilterItems/FilterItems.tsx
+++ b/src/modules/powerBI/src/Components/Filter/ExpandedFilter/FilterItems/FilterItems.tsx
@@ -32,22 +32,21 @@ export const FilterItems = ({
     controller,
     group,
 }: FilterItemsProps): JSX.Element | null => {
-    const [searchValue, setSearchValue] = useStore((store) => store.searchValue);
-    const [isSearchActive, setIsSearchActive] = useStore((store) => store.isSearchActive);
+    const [searchStore, setSearchStore] = useStore((store) => store);
 
     const parentRef = useRef<HTMLDivElement | null>(null);
     const filterRef = useRef<HTMLDivElement | null>(null);
 
     const closeSearchBox = useCallback(() => {
-        if (isSearchActive) {
-            setIsSearchActive({ isSearchActive: false });
+        if (searchStore.isSearchActive) {
+            setSearchStore({ isSearchActive: false, searchValue: '' });
         }
-    }, [isSearchActive, setIsSearchActive]);
+    }, [searchStore.isSearchActive, setSearchStore]);
 
     const filterValues = Object.values(group.value);
     const searchedFilterItems = useMemo(
-        () => searchFilterItems(filterValues, searchValue),
-        [filterValues, searchValue]
+        () => searchFilterItems(filterValues, searchStore.searchValue),
+        [filterValues, searchStore.searchValue]
     );
     const handleEnterPress = () => {
         handleOnSelectAll(
@@ -55,7 +54,7 @@ export const FilterItems = ({
             filterValues[0],
             searchedFilterItems.map((s) => s.value)
         );
-        setSearchValue({ searchValue: '' });
+        setSearchStore({ searchValue: '' });
     };
 
     const rowLength = useMemo(() => searchedFilterItems.length, [searchedFilterItems]);


### PR DESCRIPTION
# Description

When clicking outside of filter group, the search component will be closed and the search value will be reset.

Completes: AB#FILL_IN_YOUR_ISSUE_ID

## Checklist:

-   [x] I have performed a self-review of my own code.
-   [ ] I have linked my DevOps task using the AB# tag.
-   [ ] My code is easy to read, and comments are added where needed.
-   [ ] My code is covered by tests.
