### PR TITLE
[PBI & Filter] - fix:  Button styling width and height too large

### DIFF
--- a/src/modules/powerBI/src/Components/Filter/ExpandedFilter/FilterItems/Header/Styles.tsx
+++ b/src/modules/powerBI/src/Components/Filter/ExpandedFilter/FilterItems/Header/Styles.tsx
@@ -25,4 +25,8 @@ export const Title = styled.div<{ hasActiveFilters: boolean }>`
 export const SearchButton = styled(Button)`
     width: 36px;
     height: 36px;
+    ::after {
+        width: 36px;
+        height: 36px;
+    }
 `;

--- a/src/packages/Filter/Components/FilterGroup/FilterGroupStyles.ts
+++ b/src/packages/Filter/Components/FilterGroup/FilterGroupStyles.ts
@@ -77,9 +77,10 @@ export const FilterHeaderGroup = styled.div<{ isActive: boolean }>`
     min-height: 50px;
     box-sizing: border-box;
     border-bottom: ${({ isActive }) =>
-        `2px solid ${isActive
-            ? tokens.colors.interactive.primary__resting.hex
-            : tokens.colors.ui.background__medium.hex
+        `2px solid ${
+            isActive
+                ? tokens.colors.interactive.primary__resting.hex
+                : tokens.colors.ui.background__medium.hex
         }`};
 
     color: ${({ isActive }) =>
@@ -93,6 +94,10 @@ export const FilterHeaderGroup = styled.div<{ isActive: boolean }>`
 export const SearchButton = styled(Button)`
     width: 36px;
     height: 36px;
+    ::after {
+        width: 36px;
+        height: 36px;
+    }
 `;
 
 export const AllCheckbox = styled(Checkbox)`


### PR DESCRIPTION
# Description
The EDS button styling is too big which causes the onHover to fire when mouse is not actually hovering the button.

Completes: [AB#211490](https://dev.azure.com/Equinor/fa63ceea-8883-41e2-8823-a3b54e4be178/_workitems/edit/211490)

## Checklist:

-   [ ] I have performed a self-review of my own code.
-   [ ] I have linked my DevOps task using the AB# tag.
-   [ ] My code is easy to read, and comments are added where needed.
-   [ ] My code is covered by tests.
