### PR TITLE
[CommissioningProcedure] - fix: typo on commissioning

### DIFF
--- a/src/apps/apps.ts
+++ b/src/apps/apps.ts
@@ -505,8 +505,8 @@ export const apps: AppManifest[] = [
         appEnv: 'prod',
     },
     {
-        title: 'Commisisoning procedure',
-        shortName: 'commisisoning-procedure',
+        title: 'Commissioning procedure',
+        shortName: 'commissioning-procedure',
         color: '#0364B8',
         groupe: Apps.ConstructionAndCommissioning,
         icon: '',


### PR DESCRIPTION
# Description

Fixing typo on "Commissioning", it's just an external link to Fusion app, so shortname can be changed without worrying about Bookmarks saving shortname is the database. 

Completes: [AB#278552](https://dev.azure.com/Equinor/fa63ceea-8883-41e2-8823-a3b54e4be178/_workitems/edit/278552)

## Checklist:

-   [ ] I have performed a self-review of my own code.
-   [ ] I have linked my DevOps task using the AB# tag.
-   [ ] My code is easy to read, and comments are added where needed.
-   [ ] My code is covered by tests.
