### PR TITLE
[Sidesheet]- fix: make sidesheet wrapper a flexbox

### DIFF
--- a/src/packages/Sidesheet/Components/ResizableSidesheet.tsx
+++ b/src/packages/Sidesheet/Components/ResizableSidesheet.tsx
@@ -70,6 +70,10 @@ export const ResizableSidesheet = (): JSX.Element | null => {
         <div style={{ height: '100%' }}>
             <Resizable
                 size={{ width: width, height: '100%' }}
+                style={{
+                    display: 'flex',
+                    flexDirection: 'column',
+                }}
                 maxWidth={'100vw'}
                 onResizeStop={(e, direction, ref, d) => {
                     if (width + d.width < minWidth) {
@@ -101,7 +105,7 @@ export const ResizableSidesheet = (): JSX.Element | null => {
                 </Header>
 
                 <ErrorBoundary FallbackComponent={ErrorFallbackSidesheet} routeName={'Sidesheet'}>
-                    <div style={{ height: '95%' }}>
+                    <div style={{ height: '-webkit-fill-available' }}>
                         <SidesheetComponent {...sidesheetProps} />
                     </div>
                 </ErrorBoundary>


### PR DESCRIPTION
# Description
Making Resizable component a flexbox, and adjusting the height of the sidesheet content wrapper to `-webkit-fill-available'.

Some visual improvement:
* Horizontal scrollbar on the bottom of the sidesheet when x direction overflows
![image](https://user-images.githubusercontent.com/28650210/199181366-ef0aeec9-3a47-41c5-a975-ee6e68b6b066.png)


Completes: AB#FILL_IN_YOUR_ISSUE_ID

## Checklist:

-   [ ] I have performed a self-review of my own code.
-   [ ] I have linked my DevOps task using the AB# tag.
-   [ ] My code is easy to read, and comments are added where needed.
-   [ ] My code is covered by tests.
