### PR TITLE
[Filter] - fix: export memoed component

### DIFF
--- a/src/Core/WorkSpace/src/Components/QuickFilter/FilterItemCheckbox.tsx
+++ b/src/Core/WorkSpace/src/Components/QuickFilter/FilterItemCheckbox.tsx
@@ -1,3 +1,4 @@
+import { memo } from 'react';
 import { Checkbox } from '@equinor/eds-core-react';
 import { tokens } from '@equinor/eds-tokens';
 import { VirtualItem } from 'react-virtual';
@@ -19,7 +20,7 @@ interface VirtualFilterItemCheckboxProps extends FilterItemCheckboxProps {
     virtualItem: VirtualItem;
 }
 
-export const VirtualFilterItemCheckbox = ({
+const ItemCheckbox = ({
     count,
     filterValue,
     handleFilterItemClick,
@@ -48,6 +49,7 @@ export const VirtualFilterItemCheckbox = ({
         </FilterItemWrap>
     );
 };
+export const VirtualFilterItemCheckbox = memo(ItemCheckbox);
 
 const FilterLabelWrapper = styled.div`
     cursor: pointer;

--- a/src/modules/powerBI/src/Components/Filter/PopoverGroup/VirtualList.tsx
+++ b/src/modules/powerBI/src/Components/Filter/PopoverGroup/VirtualList.tsx
@@ -1,6 +1,6 @@
 import { tokens } from '@equinor/eds-tokens';
 import { VirtualFilterItemCheckbox } from '@equinor/WorkSpace';
-import { useRef, useCallback, memo } from 'react';
+import { useRef, useCallback } from 'react';
 import { useVirtual } from 'react-virtual';
 import styled from 'styled-components';
 import { PowerBiFilterItem, ActiveFilter } from '../../../Types';
@@ -36,7 +36,7 @@ export function VirtualList({
                 {rowVirtualizer.virtualItems.map((virtualRow) => {
                     const item = items[virtualRow.index];
                     return (
-                        <FilterItemValue
+                        <VirtualFilterItemCheckbox
                             virtualItem={virtualRow}
                             key={item.value}
                             ValueRender={() => <div>{item.value}</div>}
@@ -57,8 +57,6 @@ const VirtualRowWrapper = styled.div`
     min-width: 180px;
     position: relative;
 `;
-
-export const FilterItemValue = memo(VirtualFilterItemCheckbox);
 
 const Parent = styled.div`
     height: 100%;


### PR DESCRIPTION
# Description

Jest complains that VirtualFilterItemCheckbox is undefined:
 console.error
      Warning: memo: The first argument must be a component. Instead received: undefined

      59 | `;
      60 |
    > 61 | export const FilterItemValue = memo(VirtualFilterItemCheckbox);
         |                                    ^
      62 |
      63 | const Parent = styled.div`
      64 |     height: 100%;

Fixing this by wrapping the component with memo from the filter component.

Completes: AB#FILL_IN_YOUR_ISSUE_ID

## Checklist:

-   [ ] I have performed a self-review of my own code.
-   [ ] I have linked my DevOps task using the AB# tag.
-   [ ] My code is easy to read, and comments are added where needed.
-   [ ] My code is covered by tests.
