### PR TITLE
[ReleaseControl] - chore: add empty body for void request

### DIFF
--- a/src/apps/ReleaseControl/api/releaseControl/Request/voidReleaseControl.ts
+++ b/src/apps/ReleaseControl/api/releaseControl/Request/voidReleaseControl.ts
@@ -10,6 +10,7 @@ export async function voidReleaseControl({ releaseControlId }: VoidParams): Prom
 
     const requestOptions = {
         method: 'PATCH',
+        body: JSON.stringify({}),
     };
     const res = await scopeChange.fetch(
         `api/releasecontrol/${releaseControlId}/void`,


### PR DESCRIPTION
# Description

Reason for voiding/revision was added in backend API for both SCR and RC. It requires an empty body, or else the API call will fail.

Completes: AB#FILL_IN_YOUR_ISSUE_ID

## Checklist:

-   [ ] I have performed a self-review of my own code.
-   [ ] I have linked my DevOps task using the AB# tag.
-   [ ] My code is easy to read, and comments are added where needed.
-   [ ] My code is covered by tests.
