### PR TITLE
[SCR] - fix: void reason text and revision reason text

### DIFF
--- a/src/apps/ScopeChangeRequest/Components/Sidesheet/Tabs/Request/VoidedReasonBanner.tsx
+++ b/src/apps/ScopeChangeRequest/Components/Sidesheet/Tabs/Request/VoidedReasonBanner.tsx
@@ -36,8 +36,8 @@ const RevisionBanner = () => {
     const lastRevision = useMemo(() => revisions?.[0], [revisions]);
     return (
         <Container isRevision>
-            Revision {request.revisionNumber}. Reason from the person is:{' '}
-            {request.newRevisionOrVoidReason}.{' '}
+            Revision {request.revisionNumber}. This request has been revisioned{' '}
+            {request.modifiedAtUtc} by {request.modifiedBy}: {request.newRevisionOrVoidReason}.{' '}
             {lastRevision && lastRevision?.id && (
                 <Link onClick={() => openNewScopeChange(lastRevision.id)}>
                     Click here to see the latest.
@@ -49,14 +49,15 @@ const RevisionBanner = () => {
 
 export const VoidedOrRevisionBanner = (): JSX.Element | null => {
     const { request } = useScopeChangeContext();
-    if (!request.isVoided) return null;
+    const { data: revisions, isLoading } = useQuery(scopeChangeQueries.revisionsQuery(request.id));
+    if (!request.isVoided || isLoading) return null;
 
-    if (request.revisionNumber > 1) {
+    if (revisions?.length !== request.revisionNumber) {
         return <RevisionBanner />;
     }
     return (
         <Container isRevision={false}>
-            This request has been voided. Reason from the person is:{' '}
+            This request has been voided {request.modifiedAtUtc} by {request.modifiedBy}:{' '}
             {request.newRevisionOrVoidReason}
         </Container>
     );

--- a/src/apps/ScopeChangeRequest/Components/Sidesheet/Tabs/Request/VoidedReasonBanner.tsx
+++ b/src/apps/ScopeChangeRequest/Components/Sidesheet/Tabs/Request/VoidedReasonBanner.tsx
@@ -36,8 +36,14 @@ const RevisionBanner = () => {
     const lastRevision = useMemo(() => revisions?.[0], [revisions]);
     return (
         <Container isRevision>
-            Revision {request.revisionNumber}. This request has been revisioned{' '}
-            {request.modifiedAtUtc} by {request.modifiedBy}: {request.newRevisionOrVoidReason}.{' '}
+            <div>
+                Revision {request.revisionNumber}. This request has been revisioned{' '}
+                {new Date(request.modifiedAtUtc).toLocaleDateString()}
+                {request.modifiedBy &&
+                    ` by ${request.modifiedBy.firstName} ${request.modifiedBy.lastName}. Reason: `}
+                {request.newRevisionOrVoidReason}. {'  '}
+            </div>
+
             {lastRevision && lastRevision?.id && (
                 <Link onClick={() => openNewScopeChange(lastRevision.id)}>
                     Click here to see the latest.
@@ -57,7 +63,9 @@ export const VoidedOrRevisionBanner = (): JSX.Element | null => {
     }
     return (
         <Container isRevision={false}>
-            This request has been voided {request.modifiedAtUtc} by {request.modifiedBy}:{' '}
+            This request has been voided {new Date(request.modifiedAtUtc).toLocaleDateString()}{' '}
+            {request.modifiedBy &&
+                ` by ${request.modifiedBy.firstName} ${request.modifiedBy.lastName}. Reason: `}
             {request.newRevisionOrVoidReason}
         </Container>
     );

--- a/src/apps/ScopeChangeRequest/types/scopeChangeRequest.ts
+++ b/src/apps/ScopeChangeRequest/types/scopeChangeRequest.ts
@@ -124,7 +124,7 @@ export type ScopeChangeRequest = ScopeChangeBaseModel & {
     createdAtUtc: string;
     createdBy: Person;
     modifiedAtUtc: string;
-    modifiedBy: Person;
+    modifiedBy: Person | null;
     state: ScopeChangeRequestState;
     isVoided: boolean;
     currentWorkflowStep?: WorkflowStep;


### PR DESCRIPTION
# Description

Adding more info about revision and voiding. Fixed logic for when to show revision vs void banner.

Completes: [AB#293204](https://dev.azure.com/Equinor/fa63ceea-8883-41e2-8823-a3b54e4be178/_workitems/edit/293204)

## Checklist:

-   [ ] I have performed a self-review of my own code.
-   [x] I have linked my DevOps task using the AB# tag.
-   [x] My code is easy to read, and comments are added where needed.
-   [ ] My code is covered by tests.
