### PR TITLE
[Piping&HT] - chore: new url fields for pipetest/workorders

### DIFF
--- a/src/apps/DisciplineReleaseControl/Components/Sidesheet/WorkOrderTable.tsx
+++ b/src/apps/DisciplineReleaseControl/Components/Sidesheet/WorkOrderTable.tsx
@@ -1,5 +1,5 @@
 import { Button } from '@equinor/eds-core-react';
-import { isProduction } from '@equinor/lighthouse-portal-client';
+import { proCoSysUrls } from '@equinor/procosys-urls';
 import { Column, EstimateBar, ExpendedProgressBar, ProgressBar, Table } from '@equinor/Table';
 import styled from 'styled-components';
 import { WorkOrder } from '../../Types/workOrder';
@@ -14,11 +14,6 @@ const LinkContent = styled.a`
 `;
 
 export function WorkOrderTable({ workOrders }: WorkOrderTableProps): JSX.Element {
-    const getProcosysUrl = (id: string): string => {
-        const url = `https://procosys.equinor.com/JOHAN_CASTBERG/WorkOrders/WorkOrder#id=${id}`;
-        return isProduction() ? url : url.replace('procosys', 'procosystest');
-    };
-
     //Remove duplicates
     workOrders = workOrders.filter(
         (v, i, a) => a.findIndex((wo) => wo.workOrderNo === v.workOrderNo) === i
@@ -29,11 +24,11 @@ export function WorkOrderTable({ workOrders }: WorkOrderTableProps): JSX.Element
     const someColumns: Column<any>[] = [
         generateColumn(
             'WO',
-            ({ workOrderNo, sourceIdentity }) => {
+            ({ workOrderNo, workOrderUrlId }) => {
                 return (
                     <LinkContent
                         target="_BLANK"
-                        href={getProcosysUrl(sourceIdentity)}
+                        href={proCoSysUrls.getWorkOrderUrl(workOrderUrlId ?? '')}
                         rel="noreferrer"
                     >
                         <Button key="linkToProcosys" variant="ghost">

--- a/src/apps/DisciplineReleaseControl/Types/workOrder.ts
+++ b/src/apps/DisciplineReleaseControl/Types/workOrder.ts
@@ -3,6 +3,7 @@ export interface WorkOrder {
     facility: string;
     project: string;
     workOrderNo: string;
+    workOrderUrlId: string | null;
     title: string;
     description: string;
     plannedStartupDate: string;


### PR DESCRIPTION
# Description

Changing sourceIdentity to workOrderUrlId

Completes: [AB#296117](https://dev.azure.com/Equinor/fa63ceea-8883-41e2-8823-a3b54e4be178/_workitems/edit/296117)

## Checklist:

-   [ ] I have performed a self-review of my own code.
-   [ ] I have linked my DevOps task using the AB# tag.
-   [ ] My code is easy to read, and comments are added where needed.
-   [ ] My code is covered by tests.
