### PR TITLE
[SCR] fix: New SavedSearch in PCS with Project for JCA hardcoded

### DIFF
--- a/src/apps/ScopeChangeRequest/api/Search/PCS/searchQuery.ts
+++ b/src/apps/ScopeChangeRequest/api/Search/PCS/searchQuery.ts
@@ -12,8 +12,8 @@ export const searchQueryOrigin = async (
 ): Promise<TypedSelectOption[]> => {
     const selectOptions: TypedSelectOption[] = [];
 
-    const searchIdDev = 105215;
-    const searchIdProd = 105670;
+    const searchIdDev = 105263;
+    const searchIdProd = 114620;
 
     const search: PCSStructure[] = [
         {


### PR DESCRIPTION
# Description

SCR-Origin(Query) when searching, it did not take project into account on frontend. This gave backend validation errors for documents part of another project. This fix hardcodes the correct projectId to the SavedSearch - same as done in backend today.

See WI for more information.

Completes: [AB#299261](https://dev.azure.com/Equinor/fa63ceea-8883-41e2-8823-a3b54e4be178/_workitems/edit/299261)

Task: [AB#300276](https://dev.azure.com/Equinor/fa63ceea-8883-41e2-8823-a3b54e4be178/_workitems/edit/300276)

## Checklist:

-   [x] I have performed a self-review of my own code.
-   [x] I have linked my DevOps task using the AB# tag.
-   [ ] My code is easy to read, and comments are added where needed.
-   [ ] My code is covered by tests.
