### PR TITLE
chore: update browser title

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,20 +1,18 @@
 <!DOCTYPE html>
 <html lang="en">
+    <head>
+        <meta charset="UTF-8" />
+        <meta http-equiv="X-UA-Compatible" content="IE=edge" />
+        <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+        <link rel="preconnect" href="https://fonts.googleapis.com" />
+        <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+        <link rel="stylesheet" href="https://eds-static.equinor.com/font/equinor-font.css" />
+        <script type="module" src="/src/index.tsx"></script>
+        <base href="/" />
+        <title>Johan Castberg Project Portal | Fusion</title>
+    </head>
 
-<head>
-    <meta charset="UTF-8">
-    <meta http-equiv="X-UA-Compatible" content="IE=edge">
-    <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <link rel="preconnect" href="https://fonts.googleapis.com">
-    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-    <link rel="stylesheet" href="https://eds-static.equinor.com/font/equinor-font.css" />
-    <script type="module" src="/src/index.tsx"></script>
-    <base href="/">
-    <title>Fusion | Johan Castberg | Pilot</title>
-</head>
-
-<body>
-    <span id="root"></span>
-</body>
-
+    <body>
+        <span id="root"></span>
+    </body>
 </html>

--- a/src/Core/Client/Service/appConfig.ts
+++ b/src/Core/Client/Service/appConfig.ts
@@ -6,7 +6,10 @@ import { fetchClientConfig } from './envConfig';
 export async function fetchConfig(): Promise<AppConfigResult> {
     const config = await fetchClientConfig();
     const isProduction = config.CLIENT_ENV === 'prod';
-    document.title = `${config.CLIENT_ENV.toLocaleUpperCase()} | Fusion | Johan Castberg | Pilot`;
+    if (!isProduction) {
+        document.title = `${config.CLIENT_ENV.toUpperCase()} | Johan Castberg Project Portal | Fusion`;
+    }
+
     setEnv(isProduction, config.CLIENT_ENV);
 
     const response = await fetch(getEnvironmentUri(config.ENV_CONFIG_URI, config.CLIENT_ENV));


### PR DESCRIPTION
# Description

Remove ENV from browser title when in production.
Still having ENV in browser title when in dev and test.

Completes: [AB#212302](https://dev.azure.com/Equinor/fa63ceea-8883-41e2-8823-a3b54e4be178/_workitems/edit/212302)

## Checklist:

-   [ ] I have performed a self-review of my own code.
-   [ ] I have linked my DevOps task using the AB# tag.
-   [ ] My code is easy to read, and comments are added where needed.
-   [ ] My code is covered by tests.
