### PR TITLE
[SCR] - fix: styling for markdown viewer

### DIFF
--- a/src/packages/MarkdownEditor/src/MarkdownViewer/ComponentOverrides.tsx
+++ b/src/packages/MarkdownEditor/src/MarkdownViewer/ComponentOverrides.tsx
@@ -2,5 +2,5 @@ export const LI = ({ children }: { children: JSX.Element }): JSX.Element => {
     return <li style={{ fontSize: '14px' }}>{children}</li>;
 };
 export const OL = ({ children }: { children: JSX.Element }): JSX.Element => {
-    return <ol style={{ lineHeight: '10px' }}>{children}</ol>;
+    return <ol style={{ lineHeight: '1em' }}>{children}</ol>;
 };

--- a/src/packages/MarkdownEditor/src/MarkdownViewer/MarkdownViewer.tsx
+++ b/src/packages/MarkdownEditor/src/MarkdownViewer/MarkdownViewer.tsx
@@ -5,12 +5,13 @@ import { LI, OL } from './ComponentOverrides';
 // Doing it like this because of jest failing...
 const StyledMarkdown = styled((props) => <Markdown {...props} />)`
     font-size: 16px;
+    word-break: break-word;
     p {
         font-size: 16px !important;
     }
 
     ul {
-        line-height: 10px;
+        line-height: 1em;
         li::marker {
             color: #007079;
         }


### PR DESCRIPTION
# Description

Line height for old SCR in prod are not styled correctly with the MD viewer.

Completes: AB#FILL_IN_YOUR_ISSUE_ID

## Checklist:

-   [ ] I have performed a self-review of my own code.
-   [ ] I have linked my DevOps task using the AB# tag.
-   [ ] My code is easy to read, and comments are added where needed.
-   [ ] My code is covered by tests.
