### PR TITLE
[SCR] - fix: dont update state when editing attachments

### DIFF
--- a/src/apps/ScopeChangeRequest/Components/Form/ScopeChangeRequestEditForm.tsx
+++ b/src/apps/ScopeChangeRequest/Components/Form/ScopeChangeRequestEditForm.tsx
@@ -33,7 +33,7 @@ export const ScopeChangeRequestEditForm = (): JSX.Element => {
         return () => {
             clearState();
         };
-    }, [request]);
+    }, []);
 
     useUnpackRelatedObjects({ request });
 


### PR DESCRIPTION
# Description

When adding/removing attachments in `Edit mode`, the SCR state will get reset because of the dep array in this use effect. Removing the item from the dep array will cause the state to not update when editing the attachments in edit mode...

Completes: [AB#316915](https://dev.azure.com/Equinor/fa63ceea-8883-41e2-8823-a3b54e4be178/_workitems/edit/316915)

## Checklist:

-   [ ] I have performed a self-review of my own code.
-   [ ] I have linked my DevOps task using the AB# tag.
-   [ ] My code is easy to read, and comments are added where needed.
-   [ ] My code is covered by tests.
