### PR TITLE
[MarkdownEditor] - fix: add more space to new line in editor

### DIFF
--- a/src/packages/MarkdownEditor/src/editor.styles.ts
+++ b/src/packages/MarkdownEditor/src/editor.styles.ts
@@ -6,6 +6,8 @@ export const StyledContainer = styled(AllStyledComponent)`
     font-size: 16px;
     p {
         font-size: 16px !important;
+        margin-block-end: 1em !important;
+        line-height: 20px;
     }
 
     // Custom styling for unordered list items


### PR DESCRIPTION
# Description

How it is now:
![image](https://user-images.githubusercontent.com/28650210/223050707-34fac08c-089b-4b5a-8e8a-e2c25fbbd712.png)
This PR will make it look like:

![image](https://user-images.githubusercontent.com/28650210/223050800-845d0ba2-e0e1-4ed3-b9ca-6376d07719a9.png)

Completes: [AB#327579](https://dev.azure.com/Equinor/fa63ceea-8883-41e2-8823-a3b54e4be178/_workitems/edit/327579)

## Checklist:

-   [ ] I have performed a self-review of my own code.
-   [ ] I have linked my DevOps task using the AB# tag.
-   [ ] My code is easy to read, and comments are added where needed.
-   [ ] My code is covered by tests.
