### PR TITLE
fix: query client invalidation

### DIFF
--- a/src/components/Routes/Routes.tsx
+++ b/src/components/Routes/Routes.tsx
@@ -11,7 +11,7 @@ import { WorkSpace } from '../../Core/WorkSpace/src/WorkSpace';
 import { ComponentWrapper } from './ComponentWrapper';
 import { AppLoaderWrapper } from '../../fusion-framework/AppLoaderWrapper';
 import { useFramework } from '@equinor/fusion-framework-react';
-import { useQuery } from 'react-query';
+import { QueryClient, QueryClientProvider, useQuery } from 'react-query';
 import { ContextItem } from '@equinor/fusion-framework-module-context';
 import EquinorLoader from '../../fusion-framework/EquinorLoader';
 
@@ -49,6 +49,10 @@ export function ContextGuard({ children }: ContextGuardProps) {
     return <>{children}</>;
 }
 
+const queryClient = new QueryClient({
+    defaultOptions: { queries: { refetchOnWindowFocus: false } },
+});
+
 export function ClientRoutes(): JSX.Element {
     const {
         appConfig,
@@ -63,68 +67,72 @@ export function ClientRoutes(): JSX.Element {
     }, [currentRoute]);
 
     return (
-        <Routes>
-            <Route path={'/'} element={<ClientHome />} />
-            {Object.keys(appGroups).map((key) => {
-                const group = appGroups[key];
-                const links = apps.filter((app) => {
-                    return app.groupe === (key as Apps);
-                });
-                return (
-                    <Route
-                        key={key}
-                        path={`${key}`}
-                        element={<GroupView group={group} links={links} groupeId={key} />}
-                    />
-                );
-            })}
-            {apps.map((route) => {
-                if (route.app?.appType === 'Workspace') {
-                    const api = {
-                        ...route,
-                        appConfig,
-                        hasSidesheet: true,
-                        isProduction,
-                    };
+        <QueryClientProvider client={queryClient}>
+            <Routes>
+                <Route path={'/'} element={<ClientHome />} />
+                {Object.keys(appGroups).map((key) => {
+                    const group = appGroups[key];
+                    const links = apps.filter((app) => {
+                        return app.groupe === (key as Apps);
+                    });
                     return (
                         <Route
-                            key={route.shortName + route.groupe}
-                            path={`${route.groupe}/${route.shortName}/*`}
-                            element={<WorkSpace {...api} />}
+                            key={key}
+                            path={`${key}`}
+                            element={<GroupView group={group} links={links} groupeId={key} />}
                         />
                     );
-                }
-                if (route.app?.appType === 'PowerBIViewer') {
-                    return (
-                        <Route key={route.shortName + route.groupe}>
+                })}
+                {apps.map((route) => {
+                    if (route.app?.appType === 'Workspace') {
+                        const api = {
+                            ...route,
+                            appConfig,
+                            hasSidesheet: true,
+                            isProduction,
+                        };
+                        return (
                             <Route
-                                key={route.shortName}
-                                path={`${route.groupe}/${route.shortName}`}
-                                element={<PowerBiViewer {...route} />}
+                                key={route.shortName + route.groupe}
+                                path={`${route.groupe}/${route.shortName}/*`}
+                                element={<WorkSpace {...api} />}
                             />
-                        </Route>
-                    );
-                }
+                        );
+                    }
+                    if (route.app?.appType === 'PowerBIViewer') {
+                        return (
+                            <Route key={route.shortName + route.groupe}>
+                                <Route
+                                    key={route.shortName}
+                                    path={`${route.groupe}/${route.shortName}`}
+                                    element={<PowerBiViewer {...route} />}
+                                />
+                            </Route>
+                        );
+                    }
 
-                if (route.app?.appType === 'FusionApp') {
+                    if (route.app?.appType === 'FusionApp') {
+                        return (
+                            <Route
+                                key={route.shortName + route.groupe}
+                                path={`${route.groupe}/${route.shortName}/*`}
+                                element={
+                                    <AppLoaderWrapper
+                                        appKey={route.shortName.replace('-new', '')}
+                                    />
+                                }
+                            />
+                        );
+                    }
                     return (
                         <Route
-                            key={route.shortName + route.groupe}
-                            path={`${route.groupe}/${route.shortName}/*`}
-                            element={
-                                <AppLoaderWrapper appKey={route.shortName.replace('-new', '')} />
-                            }
+                            key={route.shortName}
+                            path={`${route.groupe}/${route.shortName}`}
+                            element={<ComponentWrapper {...route} />}
                         />
                     );
-                }
-                return (
-                    <Route
-                        key={route.shortName}
-                        path={`${route.groupe}/${route.shortName}`}
-                        element={<ComponentWrapper {...route} />}
-                    />
-                );
-            })}
-        </Routes>
+                })}
+            </Routes>
+        </QueryClientProvider>
     );
 }


### PR DESCRIPTION
Need to separate query clients for framework setup and applications. Calls to invalidateQueries() causes the portal to reconfigure breaking the entire thing