### PR TITLE
fix: :bug: Improved mapping of tags in create release-control workflow.

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 
 The changelog is valid starting with Castberg Project Portal v0.1.0-alpha.
 
+## 2.16.0
+
+-   [ReleaseControl] Fixed issue with unnececary commas when displaying tags in RC.
+
 ## 2.15.0
 
 -   [ReleaseControl] Add new information to the description box (while creating a RC).

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "castberg-project-portal",
-  "version": "2.15.0",
+  "version": "2.16.0",
   "description": "Castberg Project Portal",
   "main": "Index.ts",
   "author": "Castberg Project Portal Team",

--- a/src/packages/Workflow/src/Hooks/Search/useFAMSearch.ts
+++ b/src/packages/Workflow/src/Hooks/Search/useFAMSearch.ts
@@ -38,12 +38,9 @@ export function useFAMSearch(): FAMSearch {
             case 'famtag': {
                 const items = await searchTag(searchValue);
                 items.map((tag: FamTag) => {
-                    tag.relatedHTCables =
-                        (tag.heatTracingCableTagNos !== null ? tag.heatTracingCableTagNos : '') +
-                        (tag.heatTracingCableTagNos !== null ? ', ' : '') +
-                        (tag.mountedOnHeatTracingCableTagNos !== null
-                            ? tag.mountedOnHeatTracingCableTagNos
-                            : '');
+                    tag.relatedHTCables = [tag.heatTracingCableTagNos, tag.mountedOnHeatTracingCableTagNos]
+                        .filter(x => x != null)
+                        .join(",");
                     return tag;
                 });
                 return items.map(


### PR DESCRIPTION
Replaced old mapping of relatedHTCables with the use of higher order functions.

# Description

Please include a summary of the change and which issue is fixed.
List any external dependencies that are required for this change.

Completes: equinor/lighthouse-client#1511

## Checklist:

-   [X] I have performed a self-review of my own code.
-   [X] I have linked my DevOps task using the AB# tag.
-   [X] My code is easy to read, and comments are added where needed.
-   [ ] My code is covered by tests.
