### PR TITLE
feat: Added "Contains Step" filter on RC

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 
 The changelog is valid starting with Castberg Project Portal v0.1.0-alpha.
 
+## 2.17.0
+
+-   [ReleaseControl] Added new filter column for "Contains Step" to RC filters.
+
 ## 2.16.0
 
 -   [ReleaseControl] Fixed issue with unnececary commas when displaying tags in RC.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "castberg-project-portal",
-  "version": "2.16.0",
+  "version": "2.17.0",
   "description": "Castberg Project Portal",
   "main": "Index.ts",
   "author": "Castberg Project Portal Team",

--- a/src/apps/ReleaseControl/workspaceConfig/filter/filterConfig.ts
+++ b/src/apps/ReleaseControl/workspaceConfig/filter/filterConfig.ts
@@ -69,6 +69,12 @@ export const filterOptions: FilterOptions<ReleaseControl> = [
         sort: (s) => s.sort(sortOnYesNo),
     },
     {
+        name: 'Contains Step',
+        valueFormatter: ({ workflowSteps }) => {
+            return workflowSteps.map(x => x.name).filter((v, i, a) => a.indexOf(v) === i);
+        },
+    },
+    {
         name: 'Next to Sign',
         valueFormatter: (s) => getNextToSign(s),
     },


### PR DESCRIPTION
# Description
Added new filter that filters all RCs where the workflow includes a given step.

Completes: equinor/lighthouse-client#1496

## Checklist:
-   [X] I have performed a self-review of my own code.
-   [X] I have linked my DevOps task using the AB# tag.
-   [X] My code is easy to read, and comments are added where needed.
-   [ ] My code is covered by tests.
