### PR TITLE
fix: 🐛 Fixed issue with missing area in tag/HT cable tables before submitting RC

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 
 The changelog is valid starting with Castberg Project Portal v0.1.0-alpha.
 
+## 2.17.1
+
+-   [ReleaseControl] Fixed bug related to areas not showing before after submitting RC.
+
 ## 2.17.0
 
 -   [ReleaseControl] Added new filter column for "Contains Step" to RC filters.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "castberg-project-portal",
-  "version": "2.17.0",
+  "version": "2.17.1",
   "description": "Castberg Project Portal",
   "main": "Index.ts",
   "author": "Castberg Project Portal Team",

--- a/src/apps/ReleaseControl/components/Form/Inputs/Scope/HtCableTable.tsx
+++ b/src/apps/ReleaseControl/components/Form/Inputs/Scope/HtCableTable.tsx
@@ -128,7 +128,7 @@ const columns: Column<FamTagType>[] = [
     {
         id: 'area',
         Header: 'Area',
-        accessor: (item) => item.area,
+        accessor: (item) => item.area ?? item.location,
     },
     {
         id: 'remove',

--- a/src/apps/ReleaseControl/components/Form/Inputs/Scope/TagTable.tsx
+++ b/src/apps/ReleaseControl/components/Form/Inputs/Scope/TagTable.tsx
@@ -98,7 +98,7 @@ const columns: Column<FamTagType>[] = [
     {
         id: 'areas',
         Header: 'Area',
-        accessor: (item) => item.area,
+        accessor: (item) => item.area ?? item.location,
     },
     {
         id: 'remove',


### PR DESCRIPTION
# Description
Fixed issue with missing area when adding new tags/HT cables before doing submit.
Combined the location and area properties to combine data from both backend and FAM API.

Completes: equinor/lighthouse-client#1554

## Checklist:

-   [X] I have performed a self-review of my own code.
-   [X] I have linked my DevOps task using the AB# tag.
-   [X] My code is easy to read, and comments are added where needed.
-   [ ] My code is covered by tests.