### PR TITLE
feat: generic load fusion apps in JC

### DIFF
--- a/src/components/Routes/FusionAppLoader.tsx
+++ b/src/components/Routes/FusionAppLoader.tsx
@@ -1,0 +1,7 @@
+import { AppLoaderWrapper } from '../../fusion-framework/AppLoaderWrapper';
+import { useLocationKey } from '../../hooks/useLocationKey/useLocationKey';
+
+export function FusionAppLoaderRoute() {
+    const location = useLocationKey();
+    return <AppLoaderWrapper appKey={location} />;
+}

--- a/src/components/Routes/Routes.tsx
+++ b/src/components/Routes/Routes.tsx
@@ -14,6 +14,7 @@ import { useFramework } from '@equinor/fusion-framework-react';
 import { useQuery } from 'react-query';
 import { ContextItem } from '@equinor/fusion-framework-module-context';
 import EquinorLoader from '../../fusion-framework/EquinorLoader';
+import { FusionAppLoaderRoute } from './FusionAppLoader';
 
 type ContextGuardProps = {
     children: ReactNode;
@@ -65,6 +66,7 @@ export function ClientRoutes(): JSX.Element {
     return (
         <Routes>
             <Route path={'/'} element={<ClientHome />} />
+            <Route path={'/apps/*'} element={<FusionAppLoaderRoute />} />
             {Object.keys(appGroups).map((key) => {
                 const group = appGroups[key];
                 const links = apps.filter((app) => {

--- a/src/components/Routes/Routes.tsx
+++ b/src/components/Routes/Routes.tsx
@@ -66,7 +66,7 @@ export function ClientRoutes(): JSX.Element {
     return (
         <Routes>
             <Route path={'/'} element={<ClientHome />} />
-            <Route path={'/apps/*'} element={<FusionAppLoaderRoute />} />
+            <Route path={'/fusion-apps/*'} element={<FusionAppLoaderRoute />} />
             {Object.keys(appGroups).map((key) => {
                 const group = appGroups[key];
                 const links = apps.filter((app) => {

--- a/src/components/TopBar/TopBar.tsx
+++ b/src/components/TopBar/TopBar.tsx
@@ -1,7 +1,8 @@
 import { BookmarkSidesheet } from '@equinor/BookmarksManager';
-import { Popover, TopBar, Typography } from '@equinor/eds-core-react';
+import { TopBar } from '@equinor/eds-core-react';
 import { tokens } from '@equinor/eds-tokens';
-import { useClientContext, useHttpClient } from '@equinor/lighthouse-portal-client';
+import { ErrorBoundary } from '@equinor/ErrorBoundary';
+import { useClientContext } from '@equinor/lighthouse-portal-client';
 import { openSidesheet } from '@equinor/sidesheet';
 import { GlobalSearch } from '../../Core/GlobalSearh/Components/GlobalSearch';
 import { NotificationBell } from '../../Core/Notifications/Components/NotificationBell';
@@ -14,11 +15,6 @@ import { HelpMenu } from './HelpMenu';
 import Logo from './Logo/Logo';
 import { TopBarAvatar } from './TopBarAvatar';
 import { Header, Icons, TopBarWrapper } from './TopBarStyle';
-import { useRef, useState } from 'react';
-import { useOutsideClick } from '../../hooks/useOutsideClick';
-import { settings } from '@equinor/eds-icons';
-import { useQuery } from 'react-query';
-import { FusionPerson } from '../../Core/WorkSpace/src/Components/DataViewerHeader/Header';
 
 const ClientTopBar = (): JSX.Element => {
     const {
@@ -39,7 +35,9 @@ const ClientTopBar = (): JSX.Element => {
                     <Icon color={tokens.colors.interactive.primary__resting.hex} name="menu" />
                 </div>
                 <Logo />
-                <LocationBreadCrumbs />
+                <ErrorBoundary FallbackComponent={() => <div></div>}>
+                    <LocationBreadCrumbs />
+                </ErrorBoundary>
             </Header>
             <TopBar.CustomContent>
                 <DevBar env={clientEnv} />


### PR DESCRIPTION
# Description

added a /fusion-apps/* route that allows for loading any fusion app.

Nice for debugging and testing apps before migration work