### PR TITLE
ci: add build action

### DIFF
--- a/.docker/Dockerfile
+++ b/.docker/Dockerfile
@@ -9,7 +9,7 @@ COPY . /app
 RUN npm i -g pnpm@8.0.0
 RUN pnpm install
 RUN pnpm test
-RUN pnpm build 
+RUN pnpm bundle 
 
 # Production environment
 FROM nginx:1.20.2-alpine

--- a/.github/actions/pnpm-setup/action.yml
+++ b/.github/actions/pnpm-setup/action.yml
@@ -1,0 +1,20 @@
+name: PNPM setup
+description: 'Set up pnpm with cache'
+
+runs:
+  using: 'composite'
+  steps:
+    - uses: pnpm/action-setup@v2.2.4
+      with:
+        version: 8.0.0
+
+    - name: Setup Node.js environment
+      uses: actions/setup-node@v4
+      with:
+        node-version: 18
+        cache: 'pnpm'
+
+    - name: Install dependencies
+      shell: bash
+      run: pnpm install
+

--- a/.github/workflows/ci-build.yml
+++ b/.github/workflows/ci-build.yml
@@ -1,0 +1,25 @@
+name: CI
+
+on:
+  push:
+    branches: ['main']
+  pull_request:
+    types: [opened, synchronize]
+
+jobs:
+  build:
+    name: Build
+    timeout-minutes: 15
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Check out code
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 2
+
+      - name: PNPM setup
+        uses: ./.github/actions/pnpm-setup
+
+      - name: Build
+        run: pnpm build

--- a/package.json
+++ b/package.json
@@ -8,7 +8,8 @@
   "private": true,
   "scripts": {
     "start": "vite",
-    "build": "tsc && vite build",
+    "build": "tsc -b",
+    "bundle": "tsc && vite build",
     "serve": "vite preview",
     "create-config": "python ./.docker/scripts/create-client-config.py",
     "lint": "eslint --ext .js,.jsx,.ts,.tsx src --color",


### PR DESCRIPTION
Add a github action for building. This is done because it builds faster than the azure pipelines. Plan is to deprecate the pipeline integration 



I need to talk to an infra person before removing/changing the old azure pipeline configuration