### PR TITLE
feat: add double eds versions

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,8 @@
     "@cognite/sdk": "^7.3.0",
     "@cutting/use-get-parent-size": "^1.19.2",
     "@dbeining/react-atom": "^4.1.21",
-    "@equinor/eds-core-react": "0.14.2",
+    "@equinor/eds-core-react": "^0.36.0",
+    "@equinor/eds-core-react-old": "npm:@equinor/eds-core-react@0.14.2",
     "@equinor/eds-icons": "0.10.0",
     "@equinor/eds-tokens": "0.7.0",
     "@equinor/eds-utils": "0.8.3",
@@ -46,6 +47,7 @@
     "@equinor/fusion-react-progress-indicator": "^0.2.0",
     "@equinor/fusion-web-theme": "^0.1.7",
     "@esfx/async-canceltoken": "^1.0.0-pre.30",
+    "@microsoft/applicationinsights-web": "^3.0.3",
     "@microsoft/microsoft-graph-types": "^2.7.0",
     "@microsoft/signalr": "^6.0.8",
     "@remirror/pm": "^2.0.2",
@@ -90,8 +92,7 @@
     "styled-components": "^5.3.3",
     "three": "^0.158.0",
     "tinycolor2": "^1.4.2",
-    "typesafe-actions": "^5.1.0", 
-    "@microsoft/applicationinsights-web": "^3.0.3"
+    "typesafe-actions": "^5.1.0"
   },
   "devDependencies": {
     "@equinor/eslint-config-fusion": "^0.1.2",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -14,8 +14,11 @@ dependencies:
     specifier: ^4.1.21
     version: 4.1.21(react-dom@17.0.2)(react@17.0.2)
   '@equinor/eds-core-react':
-    specifier: 0.14.2
-    version: 0.14.2(react-dom@17.0.2)(react@17.0.2)(styled-components@5.3.3)
+    specifier: ^0.36.0
+    version: 0.36.0(react-dom@17.0.2)(react@17.0.2)(styled-components@5.3.3)
+  '@equinor/eds-core-react-old':
+    specifier: npm:@equinor/eds-core-react@0.14.2
+    version: /@equinor/eds-core-react@0.14.2(react-dom@17.0.2)(react@17.0.2)(styled-components@5.3.3)
   '@equinor/eds-icons':
     specifier: 0.10.0
     version: 0.10.0
@@ -725,6 +728,12 @@ packages:
     dependencies:
       regenerator-runtime: 0.14.0
 
+  /@babel/runtime@7.23.9:
+    resolution: {integrity: sha512-0CX6F+BI2s9dkUqr08KFrAIZgNFj75rdBU/DjCyYLIaV/quFjkk6T+EJ2LkZHyZTbEV4L5p97mNkUsHl2wLFAw==}
+    engines: {node: '>=6.9.0'}
+    dependencies:
+      regenerator-runtime: 0.14.0
+
   /@babel/template@7.22.15:
     resolution: {integrity: sha512-QPErUVm4uyJa60rkI73qneDacvdvzxshT3kksGqlGWYdOTIUOwJ7RDUL8sGqslY1uXWSL6xMFKEXDS3ox2uF0w==}
     engines: {node: '>=6.9.0'}
@@ -889,7 +898,7 @@ packages:
     resolution: {integrity: sha512-m4HEDZleaaCH+XgDDsPF15Ht6wTLsgDTeR3WYj9Q/k76JtWhrJjcP4+/XlG8LGT/Rol9qUfOIztXeA84ATpqPQ==}
     dependencies:
       '@babel/helper-module-imports': 7.22.15
-      '@babel/runtime': 7.23.2
+      '@babel/runtime': 7.23.9
       '@emotion/hash': 0.9.1
       '@emotion/memoize': 0.8.1
       '@emotion/serialize': 1.1.2
@@ -954,7 +963,7 @@ packages:
       '@types/react':
         optional: true
     dependencies:
-      '@babel/runtime': 7.23.2
+      '@babel/runtime': 7.23.9
       '@emotion/babel-plugin': 11.11.0
       '@emotion/cache': 11.11.0
       '@emotion/serialize': 1.1.2
@@ -990,7 +999,7 @@ packages:
       '@types/react':
         optional: true
     dependencies:
-      '@babel/runtime': 7.23.2
+      '@babel/runtime': 7.23.9
       '@emotion/babel-plugin': 11.11.0
       '@emotion/is-prop-valid': 1.2.1
       '@emotion/react': 11.11.1(@types/react@17.0.20)(react@17.0.2)
@@ -1048,8 +1057,33 @@ packages:
       styled-components: 5.3.3(@babel/core@7.23.3)(react-dom@17.0.2)(react-is@18.2.0)(react@17.0.2)
     dev: false
 
+  /@equinor/eds-core-react@0.36.0(react-dom@17.0.2)(react@17.0.2)(styled-components@5.3.3):
+    resolution: {integrity: sha512-O/WihrcxM2EjO5b/ZHFKmZ6w6NK0we6H/nvvYvmPu4iXt7Ci7lJrrEqGZfj9KeGfoX7T4wCYFEBP/nBqN7ndpQ==}
+    engines: {node: '>=10.0.0', pnpm: '>=4'}
+    peerDependencies:
+      react: '>=16.8'
+      react-dom: '>=16.8'
+      styled-components: '>=4.2'
+    dependencies:
+      '@babel/runtime': 7.23.9
+      '@equinor/eds-icons': 0.21.0
+      '@equinor/eds-tokens': 0.9.2
+      '@equinor/eds-utils': 0.8.4(react-dom@17.0.2)(react@17.0.2)(styled-components@5.3.3)
+      '@floating-ui/react': 0.26.9(react-dom@17.0.2)(react@17.0.2)
+      '@tanstack/react-virtual': 3.0.4(react-dom@17.0.2)(react@17.0.2)
+      downshift: 8.3.1(react@17.0.2)
+      react: 17.0.2
+      react-dom: 17.0.2(react@17.0.2)
+      styled-components: 5.3.3(@babel/core@7.23.3)(react-dom@17.0.2)(react-is@18.2.0)(react@17.0.2)
+    dev: false
+
   /@equinor/eds-icons@0.10.0:
     resolution: {integrity: sha512-oYnbMtBLiwp30TzN8Q/MEJdqhyAQs87oD/x/mHFQ+BpFGlbbrcsWeTOD+rNY6JhxtJl5qfi9mAhJQgRMtauXsA==}
+    engines: {node: '>=10.0.0', pnpm: '>=4'}
+    dev: false
+
+  /@equinor/eds-icons@0.21.0:
+    resolution: {integrity: sha512-k2keACHou9h9D5QLfSBeojTApqbPCkHNBWplUA/B9FQv8FMCMSBbjJAo2L/3yAExMylQN9LdwKo81T2tijRXoA==}
     engines: {node: '>=10.0.0', pnpm: '>=4'}
     dev: false
 
@@ -1082,6 +1116,21 @@ packages:
       styled-components: '>=4.2'
     dependencies:
       '@babel/runtime': 7.23.2
+      '@equinor/eds-tokens': 0.9.2
+      react: 17.0.2
+      react-dom: 17.0.2(react@17.0.2)
+      styled-components: 5.3.3(@babel/core@7.23.3)(react-dom@17.0.2)(react-is@18.2.0)(react@17.0.2)
+    dev: false
+
+  /@equinor/eds-utils@0.8.4(react-dom@17.0.2)(react@17.0.2)(styled-components@5.3.3):
+    resolution: {integrity: sha512-njvqXd3Hzfy5vkEqnx+uEBAu00vnG/5R+gDgWCReVDjjUoHdQNcrqfjBLsGF2UungtO0LbYV8YuBP+9l4V7ywQ==}
+    engines: {node: '>=10.0.0', pnpm: '>=4'}
+    peerDependencies:
+      react: '>=16.8'
+      react-dom: '>=16.8'
+      styled-components: '>=4.2'
+    dependencies:
+      '@babel/runtime': 7.23.9
       '@equinor/eds-tokens': 0.9.2
       react: 17.0.2
       react-dom: 17.0.2(react@17.0.2)
@@ -2088,20 +2137,20 @@ packages:
       '@floating-ui/utils': 0.1.6
     dev: false
 
-  /@floating-ui/dom@1.5.3:
-    resolution: {integrity: sha512-ClAbQnEqJAKCJOEbbLo5IUlZHkNszqhuxS4fHAVxRPXPya6Ysf2G8KypnYcOTpx6I8xcgF9bbHb6g/2KpbV8qA==}
+  /@floating-ui/dom@1.6.3:
+    resolution: {integrity: sha512-RnDthu3mzPlQ31Ss/BTwQ1zjzIhr3lk1gZB1OC56h/1vEtaXkESrOqL5fQVMfXpwGtRwX+YsZBdyHtJMQnkArw==}
     dependencies:
       '@floating-ui/core': 1.5.0
-      '@floating-ui/utils': 0.1.6
+      '@floating-ui/utils': 0.2.1
     dev: false
 
-  /@floating-ui/react-dom@2.0.3(react-dom@17.0.2)(react@17.0.2):
-    resolution: {integrity: sha512-wOoKUw2P24/OXbNr3bbCqWgoltsyY7lFBDPVtjj/V4WDIJ5hja2C/r+CoWmS+Y75Ahndds3wa7eJRhnJxTCJaQ==}
+  /@floating-ui/react-dom@2.0.8(react-dom@17.0.2)(react@17.0.2):
+    resolution: {integrity: sha512-HOdqOt3R3OGeTKidaLvJKcgg75S6tibQ3Tif4eyd91QnIJWr0NLvoXFpJA/j8HqkFSL68GDca9AuyWEHlhyClw==}
     peerDependencies:
       react: '>=16.8.0'
       react-dom: '>=16.8.0'
     dependencies:
-      '@floating-ui/dom': 1.5.3
+      '@floating-ui/dom': 1.6.3
       react: 17.0.2
       react-dom: 17.0.2(react@17.0.2)
     dev: false
@@ -2112,8 +2161,21 @@ packages:
       react: '>=16.8.0'
       react-dom: '>=16.8.0'
     dependencies:
-      '@floating-ui/react-dom': 2.0.3(react-dom@17.0.2)(react@17.0.2)
+      '@floating-ui/react-dom': 2.0.8(react-dom@17.0.2)(react@17.0.2)
       aria-hidden: 1.2.3
+      react: 17.0.2
+      react-dom: 17.0.2(react@17.0.2)
+      tabbable: 6.2.0
+    dev: false
+
+  /@floating-ui/react@0.26.9(react-dom@17.0.2)(react@17.0.2):
+    resolution: {integrity: sha512-p86wynZJVEkEq2BBjY/8p2g3biQ6TlgT4o/3KgFKyTWoJLU1GZ8wpctwRqtkEl2tseYA+kw7dBAIDFcednfI5w==}
+    peerDependencies:
+      react: '>=16.8.0'
+      react-dom: '>=16.8.0'
+    dependencies:
+      '@floating-ui/react-dom': 2.0.8(react-dom@17.0.2)(react@17.0.2)
+      '@floating-ui/utils': 0.2.1
       react: 17.0.2
       react-dom: 17.0.2(react@17.0.2)
       tabbable: 6.2.0
@@ -2121,6 +2183,10 @@ packages:
 
   /@floating-ui/utils@0.1.6:
     resolution: {integrity: sha512-OfX7E2oUDYxtBvsuS4e/jSn4Q9Qb6DzgeYtsAdkPZ47znpoNsMgZw0+tVijiv3uGNR6dgNlty6r9rzIzHjtd/A==}
+    dev: false
+
+  /@floating-ui/utils@0.2.1:
+    resolution: {integrity: sha512-9TANp6GPoMtYzQdt54kfAyMmz1+osLlXdg2ENroU7zzrtflTLrrC/lgrIfaSe+Wu0b89GKccT7vxXA0MoAIO+Q==}
     dev: false
 
   /@humanwhocodes/config-array@0.5.0:
@@ -2459,7 +2525,7 @@ packages:
     resolution: {integrity: sha512-8zTuIXJo5Qvjato7LWE6Q4RHiO4LjTBVOoRlqfOGYDp8VZ9w9P7Z7IJgxI7UP5Z1wiuEvnMdVF9I1C4acqXGlQ==}
     engines: {node: '>=16.0.0'}
     dependencies:
-      '@babel/runtime': 7.23.2
+      '@babel/runtime': 7.23.9
       '@lingui/message-utils': 4.5.0
       unraw: 3.0.0
     dev: false
@@ -2662,8 +2728,8 @@ packages:
       '@types/react':
         optional: true
     dependencies:
-      '@babel/runtime': 7.23.2
-      '@floating-ui/react-dom': 2.0.3(react-dom@17.0.2)(react@17.0.2)
+      '@babel/runtime': 7.23.9
+      '@floating-ui/react-dom': 2.0.8(react-dom@17.0.2)(react@17.0.2)
       '@mui/types': 7.2.8(@types/react@17.0.20)
       '@mui/utils': 5.14.17(@types/react@17.0.20)(react@17.0.2)
       '@popperjs/core': 2.11.8
@@ -2695,7 +2761,7 @@ packages:
       '@types/react':
         optional: true
     dependencies:
-      '@babel/runtime': 7.23.2
+      '@babel/runtime': 7.23.9
       '@emotion/react': 11.11.1(@types/react@17.0.20)(react@17.0.2)
       '@emotion/styled': 11.11.0(@emotion/react@11.11.1)(@types/react@17.0.20)(react@17.0.2)
       '@mui/base': 5.0.0-beta.23(@types/react@17.0.20)(react-dom@17.0.2)(react@17.0.2)
@@ -2724,7 +2790,7 @@ packages:
       '@types/react':
         optional: true
     dependencies:
-      '@babel/runtime': 7.23.2
+      '@babel/runtime': 7.23.9
       '@mui/utils': 5.14.17(@types/react@17.0.20)(react@17.0.2)
       '@types/react': 17.0.20
       prop-types: 15.8.1
@@ -2744,7 +2810,7 @@ packages:
       '@emotion/styled':
         optional: true
     dependencies:
-      '@babel/runtime': 7.23.2
+      '@babel/runtime': 7.23.9
       '@emotion/cache': 11.11.0
       '@emotion/react': 11.11.1(@types/react@17.0.20)(react@17.0.2)
       '@emotion/styled': 11.11.0(@emotion/react@11.11.1)(@types/react@17.0.20)(react@17.0.2)
@@ -2769,7 +2835,7 @@ packages:
       '@types/react':
         optional: true
     dependencies:
-      '@babel/runtime': 7.23.2
+      '@babel/runtime': 7.23.9
       '@emotion/react': 11.11.1(@types/react@17.0.20)(react@17.0.2)
       '@emotion/styled': 11.11.0(@emotion/react@11.11.1)(@types/react@17.0.20)(react@17.0.2)
       '@mui/private-theming': 5.14.17(@types/react@17.0.20)(react@17.0.2)
@@ -2804,7 +2870,7 @@ packages:
       '@types/react':
         optional: true
     dependencies:
-      '@babel/runtime': 7.23.2
+      '@babel/runtime': 7.23.9
       '@types/prop-types': 15.7.10
       '@types/react': 17.0.20
       prop-types: 15.8.1
@@ -2923,7 +2989,7 @@ packages:
       '@types/node':
         optional: true
     dependencies:
-      '@babel/runtime': 7.23.2
+      '@babel/runtime': 7.23.9
       '@remirror/core-constants': 2.0.2
       '@remirror/core-helpers': 3.0.0
       '@remirror/core-types': 2.0.5(@remirror/pm@2.0.2)
@@ -2944,7 +3010,7 @@ packages:
     peerDependencies:
       '@remirror/pm': ^2.0.7
     dependencies:
-      '@babel/runtime': 7.23.2
+      '@babel/runtime': 7.23.9
       '@linaria/core': 4.2.10
       '@remirror/core-constants': 2.0.2
       '@remirror/core-helpers': 3.0.0
@@ -2967,7 +3033,7 @@ packages:
     peerDependencies:
       '@remirror/pm': ^2.0.5
     dependencies:
-      '@babel/runtime': 7.23.2
+      '@babel/runtime': 7.23.9
       '@remirror/core': 2.0.19(@remirror/pm@2.0.2)(@types/node@17.0.10)
       '@remirror/pm': 2.0.2
       '@remirror/preset-core': 2.0.16(@remirror/pm@2.0.2)(@types/node@17.0.10)
@@ -2982,7 +3048,7 @@ packages:
     peerDependencies:
       '@remirror/pm': ^2.0.5
     dependencies:
-      '@babel/runtime': 7.23.2
+      '@babel/runtime': 7.23.9
       '@remirror/core': 2.0.19(@remirror/pm@2.0.2)(@types/node@17.0.10)
       '@remirror/extension-positioner': 2.1.8(@remirror/pm@2.0.2)(@types/node@17.0.10)
       '@remirror/messages': 2.0.6
@@ -2998,7 +3064,7 @@ packages:
     peerDependencies:
       '@remirror/pm': ^2.0.5
     dependencies:
-      '@babel/runtime': 7.23.2
+      '@babel/runtime': 7.23.9
       '@remirror/core': 2.0.19(@remirror/pm@2.0.2)(@types/node@17.0.10)
       '@remirror/messages': 2.0.6
       '@remirror/pm': 2.0.2
@@ -3015,7 +3081,7 @@ packages:
     peerDependencies:
       '@remirror/pm': ^2.0.5
     dependencies:
-      '@babel/runtime': 7.23.2
+      '@babel/runtime': 7.23.9
       '@remirror/core': 2.0.19(@remirror/pm@2.0.2)(@types/node@17.0.10)
       '@remirror/messages': 2.0.6
       '@remirror/pm': 2.0.2
@@ -3031,7 +3097,7 @@ packages:
     peerDependencies:
       '@remirror/pm': ^2.0.5
     dependencies:
-      '@babel/runtime': 7.23.2
+      '@babel/runtime': 7.23.9
       '@remirror/core': 2.0.19(@remirror/pm@2.0.2)(@types/node@17.0.10)
       '@remirror/messages': 2.0.6
       '@remirror/pm': 2.0.2
@@ -3046,7 +3112,7 @@ packages:
     peerDependencies:
       '@remirror/pm': ^2.0.5
     dependencies:
-      '@babel/runtime': 7.23.2
+      '@babel/runtime': 7.23.9
       '@remirror/core': 2.0.19(@remirror/pm@2.0.2)(@types/node@17.0.10)
       '@remirror/messages': 2.0.6
       '@remirror/pm': 2.0.2
@@ -3071,7 +3137,7 @@ packages:
       prettier:
         optional: true
     dependencies:
-      '@babel/runtime': 7.23.2
+      '@babel/runtime': 7.23.9
       '@remirror/core': 2.0.19(@remirror/pm@2.0.2)(@types/node@17.0.10)
       '@remirror/messages': 2.0.6
       '@remirror/pm': 2.0.2
@@ -3090,7 +3156,7 @@ packages:
     peerDependencies:
       '@remirror/pm': ^2.0.5
     dependencies:
-      '@babel/runtime': 7.23.2
+      '@babel/runtime': 7.23.9
       '@remirror/core': 2.0.19(@remirror/pm@2.0.2)(@types/node@17.0.10)
       '@remirror/messages': 2.0.6
       '@remirror/pm': 2.0.2
@@ -3107,7 +3173,7 @@ packages:
       '@types/codemirror': '*'
       codemirror: ^5.65.12
     dependencies:
-      '@babel/runtime': 7.23.2
+      '@babel/runtime': 7.23.9
       '@remirror/core': 2.0.19(@remirror/pm@2.0.2)(@types/node@17.0.10)
       '@remirror/messages': 2.0.6
       '@remirror/pm': 2.0.2
@@ -3124,7 +3190,7 @@ packages:
     peerDependencies:
       '@remirror/pm': ^2.0.5
     dependencies:
-      '@babel/runtime': 7.23.2
+      '@babel/runtime': 7.23.9
       '@remirror/core': 2.0.19(@remirror/pm@2.0.2)(@types/node@17.0.10)
       '@remirror/messages': 2.0.6
       '@remirror/pm': 2.0.2
@@ -3139,7 +3205,7 @@ packages:
     peerDependencies:
       '@remirror/pm': ^2.0.5
     dependencies:
-      '@babel/runtime': 7.23.2
+      '@babel/runtime': 7.23.9
       '@remirror/core': 2.0.19(@remirror/pm@2.0.2)(@types/node@17.0.10)
       '@remirror/messages': 2.0.6
       '@remirror/pm': 2.0.2
@@ -3154,7 +3220,7 @@ packages:
     peerDependencies:
       '@remirror/pm': ^2.0.5
     dependencies:
-      '@babel/runtime': 7.23.2
+      '@babel/runtime': 7.23.9
       '@remirror/core': 2.0.19(@remirror/pm@2.0.2)(@types/node@17.0.10)
       '@remirror/messages': 2.0.6
       '@remirror/pm': 2.0.2
@@ -3169,7 +3235,7 @@ packages:
     peerDependencies:
       '@remirror/pm': ^2.0.5
     dependencies:
-      '@babel/runtime': 7.23.2
+      '@babel/runtime': 7.23.9
       '@remirror/core': 2.0.19(@remirror/pm@2.0.2)(@types/node@17.0.10)
       '@remirror/messages': 2.0.6
       '@remirror/pm': 2.0.2
@@ -3184,7 +3250,7 @@ packages:
     peerDependencies:
       '@remirror/pm': ^2.0.5
     dependencies:
-      '@babel/runtime': 7.23.2
+      '@babel/runtime': 7.23.9
       '@remirror/core': 2.0.19(@remirror/pm@2.0.2)(@types/node@17.0.10)
       '@remirror/messages': 2.0.6
       '@remirror/pm': 2.0.2
@@ -3199,7 +3265,7 @@ packages:
     peerDependencies:
       '@remirror/pm': ^2.0.8
     dependencies:
-      '@babel/runtime': 7.23.2
+      '@babel/runtime': 7.23.9
       '@remirror/core': 2.0.19(@remirror/pm@2.0.2)(@types/node@17.0.10)
       '@remirror/messages': 2.0.6
       '@remirror/pm': 2.0.2
@@ -3217,7 +3283,7 @@ packages:
     peerDependencies:
       '@remirror/pm': ^2.0.5
     dependencies:
-      '@babel/runtime': 7.23.2
+      '@babel/runtime': 7.23.9
       '@ocavue/svgmoji-cjs': 0.1.1
       '@remirror/core': 2.0.19(@remirror/pm@2.0.2)(@types/node@17.0.10)
       '@remirror/messages': 2.0.6
@@ -3239,7 +3305,7 @@ packages:
     peerDependencies:
       '@remirror/pm': ^2.0.5
     dependencies:
-      '@babel/runtime': 7.23.2
+      '@babel/runtime': 7.23.9
       '@remirror/core': 2.0.19(@remirror/pm@2.0.2)(@types/node@17.0.10)
       '@remirror/extension-events': 2.1.17(@remirror/pm@2.0.2)(@types/node@17.0.10)
       '@remirror/extension-positioner': 2.1.8(@remirror/pm@2.0.2)(@types/node@17.0.10)
@@ -3255,7 +3321,7 @@ packages:
     peerDependencies:
       '@remirror/pm': ^2.0.5
     dependencies:
-      '@babel/runtime': 7.23.2
+      '@babel/runtime': 7.23.9
       '@remirror/core': 2.0.19(@remirror/pm@2.0.2)(@types/node@17.0.10)
       '@remirror/messages': 2.0.6
       '@remirror/pm': 2.0.2
@@ -3270,7 +3336,7 @@ packages:
     peerDependencies:
       '@remirror/pm': ^2.0.7
     dependencies:
-      '@babel/runtime': 7.23.2
+      '@babel/runtime': 7.23.9
       '@remirror/core': 2.0.19(@remirror/pm@2.0.2)(@types/node@17.0.10)
       '@remirror/messages': 2.0.6
       '@remirror/pm': 2.0.2
@@ -3301,7 +3367,7 @@ packages:
     peerDependencies:
       '@remirror/pm': ^2.0.5
     dependencies:
-      '@babel/runtime': 7.23.2
+      '@babel/runtime': 7.23.9
       '@remirror/core': 2.0.19(@remirror/pm@2.0.2)(@types/node@17.0.10)
       '@remirror/messages': 2.0.6
       '@remirror/pm': 2.0.2
@@ -3316,7 +3382,7 @@ packages:
     peerDependencies:
       '@remirror/pm': ^2.0.5
     dependencies:
-      '@babel/runtime': 7.23.2
+      '@babel/runtime': 7.23.9
       '@remirror/core': 2.0.19(@remirror/pm@2.0.2)(@types/node@17.0.10)
       '@remirror/messages': 2.0.6
       '@remirror/pm': 2.0.2
@@ -3332,7 +3398,7 @@ packages:
     peerDependencies:
       '@remirror/pm': ^2.0.5
     dependencies:
-      '@babel/runtime': 7.23.2
+      '@babel/runtime': 7.23.9
       '@remirror/core': 2.0.19(@remirror/pm@2.0.2)(@types/node@17.0.10)
       '@remirror/messages': 2.0.6
       '@remirror/pm': 2.0.2
@@ -3347,7 +3413,7 @@ packages:
     peerDependencies:
       '@remirror/pm': ^2.0.5
     dependencies:
-      '@babel/runtime': 7.23.2
+      '@babel/runtime': 7.23.9
       '@remirror/core': 2.0.19(@remirror/pm@2.0.2)(@types/node@17.0.10)
       '@remirror/messages': 2.0.6
       '@remirror/pm': 2.0.2
@@ -3362,7 +3428,7 @@ packages:
     peerDependencies:
       '@remirror/pm': ^2.0.5
     dependencies:
-      '@babel/runtime': 7.23.2
+      '@babel/runtime': 7.23.9
       '@remirror/core': 2.0.19(@remirror/pm@2.0.2)(@types/node@17.0.10)
       '@remirror/messages': 2.0.6
       '@remirror/pm': 2.0.2
@@ -3377,7 +3443,7 @@ packages:
     peerDependencies:
       '@remirror/pm': ^2.0.5
     dependencies:
-      '@babel/runtime': 7.23.2
+      '@babel/runtime': 7.23.9
       '@remirror/core': 2.0.19(@remirror/pm@2.0.2)(@types/node@17.0.10)
       '@remirror/messages': 2.0.6
       '@remirror/pm': 2.0.2
@@ -3392,7 +3458,7 @@ packages:
     peerDependencies:
       '@remirror/pm': ^2.0.5
     dependencies:
-      '@babel/runtime': 7.23.2
+      '@babel/runtime': 7.23.9
       '@remirror/core': 2.0.19(@remirror/pm@2.0.2)(@types/node@17.0.10)
       '@remirror/messages': 2.0.6
       '@remirror/pm': 2.0.2
@@ -3407,7 +3473,7 @@ packages:
     peerDependencies:
       '@remirror/pm': ^2.0.8
     dependencies:
-      '@babel/runtime': 7.23.2
+      '@babel/runtime': 7.23.9
       '@remirror/core': 2.0.19(@remirror/pm@2.0.2)(@types/node@17.0.10)
       '@remirror/messages': 2.0.6
       '@remirror/pm': 2.0.2
@@ -3424,7 +3490,7 @@ packages:
     peerDependencies:
       '@remirror/pm': ^2.0.5
     dependencies:
-      '@babel/runtime': 7.23.2
+      '@babel/runtime': 7.23.9
       '@remirror/core': 2.0.19(@remirror/pm@2.0.2)(@types/node@17.0.10)
       '@remirror/messages': 2.0.6
       '@remirror/pm': 2.0.2
@@ -3439,7 +3505,7 @@ packages:
     peerDependencies:
       '@remirror/pm': ^2.0.5
     dependencies:
-      '@babel/runtime': 7.23.2
+      '@babel/runtime': 7.23.9
       '@remirror/core': 2.0.19(@remirror/pm@2.0.2)(@types/node@17.0.10)
       '@remirror/extension-events': 2.1.17(@remirror/pm@2.0.2)(@types/node@17.0.10)
       '@remirror/messages': 2.0.6
@@ -3456,7 +3522,7 @@ packages:
     peerDependencies:
       '@remirror/pm': ^2.0.5
     dependencies:
-      '@babel/runtime': 7.23.2
+      '@babel/runtime': 7.23.9
       '@remirror/core': 2.0.19(@remirror/pm@2.0.2)(@types/node@17.0.10)
       '@remirror/extension-events': 2.1.17(@remirror/pm@2.0.2)(@types/node@17.0.10)
       '@remirror/messages': 2.0.6
@@ -3473,7 +3539,7 @@ packages:
     peerDependencies:
       '@remirror/pm': ^2.0.5
     dependencies:
-      '@babel/runtime': 7.23.2
+      '@babel/runtime': 7.23.9
       '@remirror/core': 2.0.19(@remirror/pm@2.0.2)(@types/node@17.0.10)
       '@remirror/messages': 2.0.6
       '@remirror/pm': 2.0.2
@@ -3493,7 +3559,7 @@ packages:
     peerDependencies:
       '@remirror/pm': ^2.0.5
     dependencies:
-      '@babel/runtime': 7.23.2
+      '@babel/runtime': 7.23.9
       '@remirror/core': 2.0.19(@remirror/pm@2.0.2)(@types/node@17.0.10)
       '@remirror/extension-events': 2.1.17(@remirror/pm@2.0.2)(@types/node@17.0.10)
       '@remirror/messages': 2.0.6
@@ -3510,7 +3576,7 @@ packages:
     peerDependencies:
       '@remirror/pm': ^2.0.5
     dependencies:
-      '@babel/runtime': 7.23.2
+      '@babel/runtime': 7.23.9
       '@remirror/core': 2.0.19(@remirror/pm@2.0.2)(@types/node@17.0.10)
       '@remirror/extension-events': 2.1.17(@remirror/pm@2.0.2)(@types/node@17.0.10)
       '@remirror/messages': 2.0.6
@@ -3527,7 +3593,7 @@ packages:
     peerDependencies:
       '@remirror/pm': ^2.0.5
     dependencies:
-      '@babel/runtime': 7.23.2
+      '@babel/runtime': 7.23.9
       '@remirror/core': 2.0.19(@remirror/pm@2.0.2)(@types/node@17.0.10)
       '@remirror/messages': 2.0.6
       '@remirror/pm': 2.0.2
@@ -3542,7 +3608,7 @@ packages:
     peerDependencies:
       '@remirror/pm': ^2.0.5
     dependencies:
-      '@babel/runtime': 7.23.2
+      '@babel/runtime': 7.23.9
       '@remirror/core': 2.0.19(@remirror/pm@2.0.2)(@types/node@17.0.10)
       '@remirror/messages': 2.0.6
       '@remirror/pm': 2.0.2
@@ -3557,7 +3623,7 @@ packages:
     peerDependencies:
       '@remirror/pm': ^2.0.5
     dependencies:
-      '@babel/runtime': 7.23.2
+      '@babel/runtime': 7.23.9
       '@remirror/core': 2.0.19(@remirror/pm@2.0.2)(@types/node@17.0.10)
       '@remirror/messages': 2.0.6
       '@remirror/pm': 2.0.2
@@ -3573,7 +3639,7 @@ packages:
     peerDependencies:
       '@remirror/pm': ^2.0.5
     dependencies:
-      '@babel/runtime': 7.23.2
+      '@babel/runtime': 7.23.9
       '@remirror/core': 2.0.19(@remirror/pm@2.0.2)(@types/node@17.0.10)
       '@remirror/extension-events': 2.1.17(@remirror/pm@2.0.2)(@types/node@17.0.10)
       '@remirror/messages': 2.0.6
@@ -3600,7 +3666,7 @@ packages:
       '@types/react-dom':
         optional: true
     dependencies:
-      '@babel/runtime': 7.23.2
+      '@babel/runtime': 7.23.9
       '@remirror/core': 2.0.19(@remirror/pm@2.0.2)(@types/node@17.0.10)
       '@remirror/messages': 2.0.6
       '@remirror/pm': 2.0.2
@@ -3627,7 +3693,7 @@ packages:
       react-dom:
         optional: true
     dependencies:
-      '@babel/runtime': 7.23.2
+      '@babel/runtime': 7.23.9
       '@emotion/css': 11.11.2
       '@linaria/core': 4.2.10
       '@remirror/core': 2.0.19(@remirror/pm@2.0.2)(@types/node@17.0.10)
@@ -3659,7 +3725,7 @@ packages:
     peerDependencies:
       '@remirror/pm': ^2.0.5
     dependencies:
-      '@babel/runtime': 7.23.2
+      '@babel/runtime': 7.23.9
       '@remirror/core': 2.0.19(@remirror/pm@2.0.2)(@types/node@17.0.10)
       '@remirror/messages': 2.0.6
       '@remirror/pm': 2.0.2
@@ -3675,7 +3741,7 @@ packages:
     peerDependencies:
       '@remirror/pm': ^2.0.5
     dependencies:
-      '@babel/runtime': 7.23.2
+      '@babel/runtime': 7.23.9
       '@remirror/core': 2.0.19(@remirror/pm@2.0.2)(@types/node@17.0.10)
       '@remirror/pm': 2.0.2
     transitivePeerDependencies:
@@ -3689,7 +3755,7 @@ packages:
     peerDependencies:
       '@remirror/pm': ^2.0.5
     dependencies:
-      '@babel/runtime': 7.23.2
+      '@babel/runtime': 7.23.9
       '@remirror/core': 2.0.19(@remirror/pm@2.0.2)(@types/node@17.0.10)
       '@remirror/messages': 2.0.6
       '@remirror/pm': 2.0.2
@@ -3704,7 +3770,7 @@ packages:
     peerDependencies:
       '@remirror/pm': ^2.0.5
     dependencies:
-      '@babel/runtime': 7.23.2
+      '@babel/runtime': 7.23.9
       '@remirror/core': 2.0.19(@remirror/pm@2.0.2)(@types/node@17.0.10)
       '@remirror/messages': 2.0.6
       '@remirror/pm': 2.0.2
@@ -3719,7 +3785,7 @@ packages:
     peerDependencies:
       '@remirror/pm': ^2.0.5
     dependencies:
-      '@babel/runtime': 7.23.2
+      '@babel/runtime': 7.23.9
       '@remirror/core': 2.0.19(@remirror/pm@2.0.2)(@types/node@17.0.10)
       '@remirror/messages': 2.0.6
       '@remirror/pm': 2.0.2
@@ -3734,7 +3800,7 @@ packages:
     peerDependencies:
       '@remirror/pm': ^2.0.7
     dependencies:
-      '@babel/runtime': 7.23.2
+      '@babel/runtime': 7.23.9
       '@remirror/core': 2.0.19(@remirror/pm@2.0.2)(@types/node@17.0.10)
       '@remirror/extension-events': 2.1.17(@remirror/pm@2.0.2)(@types/node@17.0.10)
       '@remirror/extension-positioner': 2.1.8(@remirror/pm@2.0.2)(@types/node@17.0.10)
@@ -3752,7 +3818,7 @@ packages:
     peerDependencies:
       '@remirror/pm': ^2.0.5
     dependencies:
-      '@babel/runtime': 7.23.2
+      '@babel/runtime': 7.23.9
       '@remirror/core': 2.0.19(@remirror/pm@2.0.2)(@types/node@17.0.10)
       '@remirror/messages': 2.0.6
       '@remirror/pm': 2.0.2
@@ -3767,7 +3833,7 @@ packages:
     peerDependencies:
       '@remirror/pm': ^2.0.5
     dependencies:
-      '@babel/runtime': 7.23.2
+      '@babel/runtime': 7.23.9
       '@remirror/core': 2.0.19(@remirror/pm@2.0.2)(@types/node@17.0.10)
       '@remirror/i18n': 2.0.5
       '@remirror/messages': 2.0.6
@@ -3785,7 +3851,7 @@ packages:
     peerDependencies:
       '@remirror/pm': ^2.0.5
     dependencies:
-      '@babel/runtime': 7.23.2
+      '@babel/runtime': 7.23.9
       '@remirror/core': 2.0.19(@remirror/pm@2.0.2)(@types/node@17.0.10)
       '@remirror/extension-text-color': 2.0.15(@remirror/pm@2.0.2)(@types/node@17.0.10)
       '@remirror/messages': 2.0.6
@@ -3801,7 +3867,7 @@ packages:
     peerDependencies:
       '@remirror/pm': ^2.0.5
     dependencies:
-      '@babel/runtime': 7.23.2
+      '@babel/runtime': 7.23.9
       '@remirror/core': 2.0.19(@remirror/pm@2.0.2)(@types/node@17.0.10)
       '@remirror/messages': 2.0.6
       '@remirror/pm': 2.0.2
@@ -3816,7 +3882,7 @@ packages:
     peerDependencies:
       '@remirror/pm': ^2.0.5
     dependencies:
-      '@babel/runtime': 7.23.2
+      '@babel/runtime': 7.23.9
       '@remirror/core': 2.0.19(@remirror/pm@2.0.2)(@types/node@17.0.10)
       '@remirror/messages': 2.0.6
       '@remirror/pm': 2.0.2
@@ -3831,7 +3897,7 @@ packages:
     peerDependencies:
       '@remirror/pm': ^2.0.5
     dependencies:
-      '@babel/runtime': 7.23.2
+      '@babel/runtime': 7.23.9
       '@remirror/core': 2.0.19(@remirror/pm@2.0.2)(@types/node@17.0.10)
       '@remirror/messages': 2.0.6
       '@remirror/pm': 2.0.2
@@ -3846,7 +3912,7 @@ packages:
     peerDependencies:
       '@remirror/pm': ^2.0.5
     dependencies:
-      '@babel/runtime': 7.23.2
+      '@babel/runtime': 7.23.9
       '@remirror/core': 2.0.19(@remirror/pm@2.0.2)(@types/node@17.0.10)
       '@remirror/messages': 2.0.6
       '@remirror/pm': 2.0.2
@@ -3862,7 +3928,7 @@ packages:
       '@remirror/pm': ^2.0.8
       yjs: ^13.6.1
     dependencies:
-      '@babel/runtime': 7.23.2
+      '@babel/runtime': 7.23.9
       '@remirror/core': 2.0.19(@remirror/pm@2.0.2)(@types/node@17.0.10)
       '@remirror/messages': 2.0.6
       '@remirror/pm': 2.0.2
@@ -3881,7 +3947,7 @@ packages:
   /@remirror/i18n@2.0.5:
     resolution: {integrity: sha512-oZ2umZav60iu+lBoVZxr7i11yUNRYpczVUXCsClNiHN55PDPMyYwNQ9CaEJdyQCvt0lb5WCmBNpnw1mbLaj7lQ==}
     dependencies:
-      '@babel/runtime': 7.23.2
+      '@babel/runtime': 7.23.9
       '@lingui/core': 4.5.0
       '@lingui/detect-locale': 4.5.0
       '@remirror/core-helpers': 3.0.0
@@ -3891,14 +3957,14 @@ packages:
   /@remirror/icons@2.0.3:
     resolution: {integrity: sha512-ruOGU4FT6WJdXsdVwfNOurSaQvnk2Uo4AkMxxyLYkBPowxmR9Xe0lOn7d7UARai0wxmwFgX6IYaMSUVLIaaMCQ==}
     dependencies:
-      '@babel/runtime': 7.23.2
+      '@babel/runtime': 7.23.9
       '@remirror/core-helpers': 3.0.0
     dev: false
 
   /@remirror/messages@2.0.6:
     resolution: {integrity: sha512-JVnfuzuul4tcvnjiSM7Jj6iKDOP4hfaw79SciZ7t+cc2+iWyAcDYSrFMDV4Q50T+2IfWTYlWtKGpIhG6sfZaWw==}
     dependencies:
-      '@babel/runtime': 7.23.2
+      '@babel/runtime': 7.23.9
       '@lingui/core': 4.5.0
       '@remirror/core-helpers': 3.0.0
     dev: false
@@ -3934,7 +4000,7 @@ packages:
     peerDependencies:
       '@remirror/pm': ^2.0.5
     dependencies:
-      '@babel/runtime': 7.23.2
+      '@babel/runtime': 7.23.9
       '@remirror/core': 2.0.19(@remirror/pm@2.0.2)(@types/node@17.0.10)
       '@remirror/extension-doc': 2.1.5(@remirror/pm@2.0.2)(@types/node@17.0.10)
       '@remirror/extension-events': 2.1.17(@remirror/pm@2.0.2)(@types/node@17.0.10)
@@ -3955,7 +4021,7 @@ packages:
     peerDependencies:
       '@remirror/pm': ^2.0.5
     dependencies:
-      '@babel/runtime': 7.23.2
+      '@babel/runtime': 7.23.9
       '@remirror/core': 2.0.19(@remirror/pm@2.0.2)(@types/node@17.0.10)
       '@remirror/extension-bold': 2.0.13(@remirror/pm@2.0.2)(@types/node@17.0.10)
       '@remirror/extension-columns': 2.0.14(@remirror/pm@2.0.2)(@types/node@17.0.10)
@@ -3992,7 +4058,7 @@ packages:
       '@types/react-dom':
         optional: true
     dependencies:
-      '@babel/runtime': 7.23.2
+      '@babel/runtime': 7.23.9
       '@remirror/core': 2.0.19(@remirror/pm@2.0.2)(@types/node@17.0.10)
       '@remirror/extension-placeholder': 2.0.14(@remirror/pm@2.0.2)(@types/node@17.0.10)
       '@remirror/extension-react-component': 2.0.13(@remirror/pm@2.0.2)(@types/node@17.0.10)(@types/react-dom@17.0.9)(@types/react@17.0.20)(react-dom@17.0.2)(react@17.0.2)
@@ -4013,7 +4079,7 @@ packages:
     peerDependencies:
       '@remirror/pm': ^2.0.5
     dependencies:
-      '@babel/runtime': 7.23.2
+      '@babel/runtime': 7.23.9
       '@remirror/core': 2.0.19(@remirror/pm@2.0.2)(@types/node@17.0.10)
       '@remirror/extension-bidi': 2.0.14(@remirror/pm@2.0.2)(@types/node@17.0.10)
       '@remirror/extension-blockquote': 2.0.14(@remirror/pm@2.0.2)(@types/node@17.0.10)
@@ -4059,7 +4125,7 @@ packages:
       '@types/react-dom':
         optional: true
     dependencies:
-      '@babel/runtime': 7.23.2
+      '@babel/runtime': 7.23.9
       '@emotion/react': 11.11.1(@types/react@17.0.20)(react@17.0.2)
       '@emotion/styled': 11.11.0(@emotion/react@11.11.1)(@types/react@17.0.20)(react@17.0.2)
       '@floating-ui/react': 0.24.8(react-dom@17.0.2)(react@17.0.2)
@@ -4128,7 +4194,7 @@ packages:
       '@types/react-dom':
         optional: true
     dependencies:
-      '@babel/runtime': 7.23.2
+      '@babel/runtime': 7.23.9
       '@remirror/core': 2.0.19(@remirror/pm@2.0.2)(@types/node@17.0.10)
       '@remirror/extension-positioner': 2.1.8(@remirror/pm@2.0.2)(@types/node@17.0.10)
       '@remirror/extension-react-component': 2.0.13(@remirror/pm@2.0.2)(@types/node@17.0.10)(@types/react-dom@17.0.9)(@types/react@17.0.20)(react-dom@17.0.2)(react@17.0.2)
@@ -4172,7 +4238,7 @@ packages:
       react-dom:
         optional: true
     dependencies:
-      '@babel/runtime': 7.23.2
+      '@babel/runtime': 7.23.9
       '@remirror/core': 2.0.19(@remirror/pm@2.0.2)(@types/node@17.0.10)
       '@remirror/extension-emoji': 2.0.17(@remirror/pm@2.0.2)(@types/node@17.0.10)
       '@remirror/extension-events': 2.1.17(@remirror/pm@2.0.2)(@types/node@17.0.10)
@@ -4206,7 +4272,7 @@ packages:
       '@types/react':
         optional: true
     dependencies:
-      '@babel/runtime': 7.23.2
+      '@babel/runtime': 7.23.9
       '@remirror/core': 2.0.19(@remirror/pm@2.0.2)(@types/node@17.0.10)
       '@types/react': 17.0.20
       react: 17.0.2
@@ -4226,7 +4292,7 @@ packages:
       '@types/react':
         optional: true
     dependencies:
-      '@babel/runtime': 7.23.2
+      '@babel/runtime': 7.23.9
       '@remirror/core-constants': 2.0.2
       '@remirror/core-helpers': 3.0.0
       '@remirror/core-types': 2.0.5(@remirror/pm@2.0.2)
@@ -4311,7 +4377,7 @@ packages:
   /@remirror/theme@2.0.9(@remirror/pm@2.0.2):
     resolution: {integrity: sha512-MI6j7C9KImVyfSBh9GR/WQCuLQKXRKQkE0HsS8Sc/BC8a/0n4QTt7dAg5/a/+MbakyymNaGlibCdts8URgGStg==}
     dependencies:
-      '@babel/runtime': 7.23.2
+      '@babel/runtime': 7.23.9
       '@linaria/core': 4.2.10
       '@remirror/core-types': 2.0.5(@remirror/pm@2.0.2)
       color2k: 2.0.2
@@ -4459,14 +4525,14 @@ packages:
   /@svgmoji/blob@3.2.0:
     resolution: {integrity: sha512-N96WOrH9GxPSPZ/FuvZl6T9Rh54stAEuUcBppIRFh9/WwkU7Hczrjabw4uunwxFLX5TgR+rHlKJl3/jaTnXJrQ==}
     dependencies:
-      '@babel/runtime': 7.23.2
+      '@babel/runtime': 7.23.9
       '@svgmoji/core': 3.2.0
     dev: false
 
   /@svgmoji/core@3.2.0:
     resolution: {integrity: sha512-QsD78Op3S/5kUVsa5ierr4Wu/xwAdYuMI3Zmc/Y2ekYBEMGEUY8QxilXQRSAQ4ku4PnNV4xlB9e7xhD5hy113A==}
     dependencies:
-      '@babel/runtime': 7.23.2
+      '@babel/runtime': 7.23.9
       emojibase: 5.2.0
       emojibase-regex: 5.1.3
       idb-keyval: 5.1.5
@@ -4477,22 +4543,37 @@ packages:
   /@svgmoji/noto@3.2.0:
     resolution: {integrity: sha512-JgtNciB06hMDI1Pb1N2IgLh44XRMZUUNwBANzjY5jXTPqOCu1A1VA35ENvUsRhEUZOm8I+hbdAEHkwMVqxLeIQ==}
     dependencies:
-      '@babel/runtime': 7.23.2
+      '@babel/runtime': 7.23.9
       '@svgmoji/core': 3.2.0
     dev: false
 
   /@svgmoji/openmoji@3.2.0:
     resolution: {integrity: sha512-USHbG+O80HfmdoNAHbOnlO+2gppXJfHFWKSRFj53Th4aimWEx4/9MB3cFbC3KZ1NOqXaLBq9jDaw4vFuGDVTUQ==}
     dependencies:
-      '@babel/runtime': 7.23.2
+      '@babel/runtime': 7.23.9
       '@svgmoji/core': 3.2.0
     dev: false
 
   /@svgmoji/twemoji@3.2.0:
     resolution: {integrity: sha512-6xqZgh9viFDKf5wvrxw56ImCR3Ni84IqwK45lxojOe1Gc1Mni1GpPfr4gb7WHDKjumfx+K7BHSvX0KXt3Nr3CQ==}
     dependencies:
-      '@babel/runtime': 7.23.2
+      '@babel/runtime': 7.23.9
       '@svgmoji/core': 3.2.0
+    dev: false
+
+  /@tanstack/react-virtual@3.0.4(react-dom@17.0.2)(react@17.0.2):
+    resolution: {integrity: sha512-tiqKW/e2MJVCr7/pRUXulpkyxllaOclkHNfhKTo4pmHjJIqnhMfwIjc1Q1R0Un3PI3kQywywu/791c8z9u0qeA==}
+    peerDependencies:
+      react: ^16.8.0 || ^17.0.0 || ^18.0.0
+      react-dom: ^16.8.0 || ^17.0.0 || ^18.0.0
+    dependencies:
+      '@tanstack/virtual-core': 3.0.0
+      react: 17.0.2
+      react-dom: 17.0.2(react@17.0.2)
+    dev: false
+
+  /@tanstack/virtual-core@3.0.0:
+    resolution: {integrity: sha512-SYXOBTjJb05rXa2vl55TTwO40A6wKu0R5i1qQwhJYNDIqaIGF7D0HsLw+pJAyi2OvntlEIVusx3xtbbgSUi6zg==}
     dev: false
 
   /@testing-library/dom@8.20.1:
@@ -4514,7 +4595,7 @@ packages:
     engines: {node: '>=14'}
     dependencies:
       '@babel/code-frame': 7.22.13
-      '@babel/runtime': 7.23.2
+      '@babel/runtime': 7.23.9
       '@types/aria-query': 5.0.4
       aria-query: 5.1.3
       chalk: 4.1.2
@@ -5235,7 +5316,7 @@ packages:
   /a11y-status@2.0.1:
     resolution: {integrity: sha512-VcW0aF3xb5wYFDYEfK7u41HBIU/bCE9zWl4zG+RhW1g0jGgTdS3h4ulVjVs7/2+KbGMpZvafP7wf/CDs/duNtA==}
     dependencies:
-      '@babel/runtime': 7.23.2
+      '@babel/runtime': 7.23.9
       '@types/throttle-debounce': 2.1.0
       throttle-debounce: 3.0.1
     dev: false
@@ -5563,7 +5644,7 @@ packages:
     resolution: {integrity: sha512-Cg7TFGpIr01vOQNODXOOaGz2NpCU5gl8x1qJFbb6hbZxR7XrcE2vtbAsTAbJ7/xwJtUuJEw8K8Zr/AE0LHlesg==}
     engines: {node: '>=10', npm: '>=6'}
     dependencies:
-      '@babel/runtime': 7.23.2
+      '@babel/runtime': 7.23.9
       cosmiconfig: 7.1.0
       resolve: 1.22.8
     dev: false
@@ -5662,7 +5743,7 @@ packages:
   /broadcast-channel@3.7.0:
     resolution: {integrity: sha512-cIAKJXAxGJceNZGTZSBzMxzyOn72cVgPnKx4dc6LRjQgbaJUQqhy5rzL3zbMxkMWsGKkv2hSFkPRMEXfoMZ2Mg==}
     dependencies:
-      '@babel/runtime': 7.23.2
+      '@babel/runtime': 7.23.9
       detect-node: 2.1.0
       js-sha3: 0.8.0
       microseconds: 0.2.0
@@ -5931,6 +6012,10 @@ packages:
     resolution: {integrity: sha512-UCB0ioiyj8CRjtrvaceBLqqhZCVP+1B8+NWQhmdsm0VXOJtobBCf1dBQmebCCo34qZmUwZfIH2MZLqNHazrfjg==}
     dev: false
 
+  /compute-scroll-into-view@3.1.0:
+    resolution: {integrity: sha512-rj8l8pD4bJ1nx+dAkMhV1xB5RuZEyVysfxJqB1pRchh1KVvwOv9b7CGB8ZfjTImVv2oF+sYMUkMZq6Na5Ftmbg==}
+    dev: false
+
   /concat-map@0.0.1:
     resolution: {integrity: sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==}
 
@@ -5978,7 +6063,7 @@ packages:
       '@types/react':
         optional: true
     dependencies:
-      '@babel/runtime': 7.23.2
+      '@babel/runtime': 7.23.9
       '@types/react': 17.0.20
       react: 17.0.2
     dev: false
@@ -6093,7 +6178,7 @@ packages:
     resolution: {integrity: sha512-fnULvOpxnC5/Vg3NCiWelDsLiUc9bRwAPs/+LfTLNvetFCtCTN+yQz15C/fs4AwX1R9K5GLtLfn8QW+dWisaAw==}
     engines: {node: '>=0.11'}
     dependencies:
-      '@babel/runtime': 7.23.2
+      '@babel/runtime': 7.23.9
     dev: false
 
   /debug@4.3.4(supports-color@5.5.0):
@@ -6255,7 +6340,7 @@ packages:
   /dom-helpers@5.2.1:
     resolution: {integrity: sha512-nRCa7CK3VTrM2NmGkIy4cbK7IZlgBE/PYMn55rrXefr5xXDP0LdtfPnblFDoVdcAfslJ7or6iqAUnx0CCGIWQA==}
     dependencies:
-      '@babel/runtime': 7.23.2
+      '@babel/runtime': 7.23.9
       csstype: 3.1.2
     dev: false
 
@@ -6283,11 +6368,24 @@ packages:
     peerDependencies:
       react: '>=16.12.0'
     dependencies:
-      '@babel/runtime': 7.23.2
+      '@babel/runtime': 7.23.9
       compute-scroll-into-view: 1.0.20
-      prop-types: 15.7.2
+      prop-types: 15.8.1
       react: 17.0.2
       react-is: 17.0.2
+      tslib: 2.6.2
+    dev: false
+
+  /downshift@8.3.1(react@17.0.2):
+    resolution: {integrity: sha512-djPzjGfTSEjOsfmlur4onCV3Mtd6oGI+eOQIBNwoS7oEYTjPrxk6n+sJLmndT/KKwHvUyBSh3AFb64eHIFifTQ==}
+    peerDependencies:
+      react: '>=16.12.0'
+    dependencies:
+      '@babel/runtime': 7.23.9
+      compute-scroll-into-view: 3.1.0
+      prop-types: 15.8.1
+      react: 17.0.2
+      react-is: 18.2.0
       tslib: 2.6.2
     dev: false
 
@@ -7369,7 +7467,7 @@ packages:
   /history@5.3.0:
     resolution: {integrity: sha512-ZqaKwjjrAYUYfLG+htGaIIZ4nioX2L70ZUMIFysS3xvBsSG4x/n1V6TXV3N8ZYNuFGlDirFg32T7B6WOUPDYcQ==}
     dependencies:
-      '@babel/runtime': 7.23.2
+      '@babel/runtime': 7.23.9
 
   /hoist-non-react-statics@3.3.2:
     resolution: {integrity: sha512-/gGivxi8JPKWNm/W0jSmzcMPpfpPLc3dY/6GxhX2hQ9iGj3aDfklV4ET7NjKpSinLpJ5vafa9iiGIEZg10SfBw==}
@@ -8615,7 +8713,7 @@ packages:
   /match-sorter@6.3.1:
     resolution: {integrity: sha512-mxybbo3pPNuA+ZuCUhm5bwNkXrJTbsk5VWbR5wiwz/GC6LIiegBGn2w3O08UG/jdbYLinw51fSQ5xNU1U3MgBw==}
     dependencies:
-      '@babel/runtime': 7.23.2
+      '@babel/runtime': 7.23.9
       remove-accents: 0.4.2
     dev: false
 
@@ -8755,7 +8853,7 @@ packages:
       '@types/react':
         optional: true
     dependencies:
-      '@babel/runtime': 7.23.2
+      '@babel/runtime': 7.23.9
       '@remirror/core-helpers': 3.0.0
       '@remirror/core-types': 2.0.5(@remirror/pm@2.0.2)
       '@seznam/compose-react-refs': 1.0.6
@@ -9383,7 +9481,7 @@ packages:
       prosemirror-state: ^1.4.2
       prosemirror-view: ^1.31.2
     dependencies:
-      '@babel/runtime': 7.23.2
+      '@babel/runtime': 7.23.9
       '@remirror/core-constants': 2.0.2
       '@remirror/core-helpers': 3.0.0
       escape-string-regexp: 4.0.0
@@ -9395,7 +9493,7 @@ packages:
   /prosemirror-resizable-view@2.0.14(@remirror/pm@2.0.2)(@types/node@17.0.10):
     resolution: {integrity: sha512-TgCaOWaMdR/R34AYsxHtHuQlC9rtHTuSBEgcmD5V9ldVe1+Ul72xz9G73xo9wLhVpTwt3YxzpenTcRWPZIofow==}
     dependencies:
-      '@babel/runtime': 7.23.2
+      '@babel/runtime': 7.23.9
       '@remirror/core-helpers': 3.0.0
       '@remirror/core-utils': 2.0.13(@remirror/pm@2.0.2)(@types/node@17.0.10)
       prosemirror-model: 1.19.3
@@ -9429,7 +9527,7 @@ packages:
       prosemirror-state: ^1.4.2
       prosemirror-view: ^1.31.2
     dependencies:
-      '@babel/runtime': 7.23.2
+      '@babel/runtime': 7.23.9
       '@remirror/core-constants': 2.0.2
       '@remirror/core-helpers': 3.0.0
       '@remirror/types': 1.0.1
@@ -9549,7 +9647,7 @@ packages:
       lodash: 4.17.21
       lodash-es: 4.17.21
       material-colors: 1.2.6
-      prop-types: 15.7.2
+      prop-types: 15.8.1
       react: 17.0.2
       reactcss: 1.2.3(react@17.0.2)
       tinycolor2: 1.4.2
@@ -9721,10 +9819,10 @@ packages:
       react: '>=16.6.0'
       react-dom: '>=16.6.0'
     dependencies:
-      '@babel/runtime': 7.23.2
+      '@babel/runtime': 7.23.9
       dom-helpers: 5.2.1
       loose-envify: 1.4.0
-      prop-types: 15.7.2
+      prop-types: 15.8.1
       react: 17.0.2
       react-dom: 17.0.2(react@17.0.2)
     dev: false
@@ -10523,7 +10621,7 @@ packages:
   /svgmoji@3.2.0:
     resolution: {integrity: sha512-tjmdQhIju2ZQ81FLBlPngg1aWMOhQjP9ErXb2ROikM0aBGA/hqI0/DN/5J0sDsXzJPHmODpSFhWfiSsUieU3bA==}
     dependencies:
-      '@babel/runtime': 7.23.2
+      '@babel/runtime': 7.23.9
       '@svgmoji/blob': 3.2.0
       '@svgmoji/core': 3.2.0
       '@svgmoji/noto': 3.2.0
@@ -10948,7 +11046,7 @@ packages:
   /unload@2.2.0:
     resolution: {integrity: sha512-B60uB5TNBLtN6/LsgAf3udH9saB5p7gqJwcFfbOEZ8BcBHnGwCf6G/TGiEqkRAxX7zAFIUtzdrXQSdL3Q/wqNA==}
     dependencies:
-      '@babel/runtime': 7.23.2
+      '@babel/runtime': 7.23.9
       detect-node: 2.1.0
     dev: false
 

--- a/src/Core/Assignments/Components/AssignmentsTab.tsx
+++ b/src/Core/Assignments/Components/AssignmentsTab.tsx
@@ -1,4 +1,4 @@
-import { Chip, Checkbox, CircularProgress } from '@equinor/eds-core-react';
+import { Chip, Checkbox, CircularProgress } from '@equinor/eds-core-react-old';
 import { tokens } from '@equinor/eds-tokens';
 import { useEffect, useMemo, useState } from 'react';
 

--- a/src/Core/Client/ClientLoad/ClientFailed.tsx
+++ b/src/Core/Client/ClientLoad/ClientFailed.tsx
@@ -1,4 +1,4 @@
-import { Icon } from '@equinor/eds-core-react';
+import { Icon } from '@equinor/eds-core-react-old';
 import { tokens } from '@equinor/eds-tokens';
 import styled from 'styled-components';
 import { Fullscreen } from './client.styles';

--- a/src/Core/Client/ClientLoad/ClientLoading.tsx
+++ b/src/Core/Client/ClientLoad/ClientLoading.tsx
@@ -1,4 +1,4 @@
-import { Progress } from '@equinor/eds-core-react';
+import { Progress } from '@equinor/eds-core-react-old';
 import { Fullscreen } from './client.styles';
 
 export const ClientLoading = (): JSX.Element => {

--- a/src/Core/Client/Home/clientHome.tsx
+++ b/src/Core/Client/Home/clientHome.tsx
@@ -1,4 +1,4 @@
-import { Typography } from '@equinor/eds-core-react';
+import { Typography } from '@equinor/eds-core-react-old';
 import { useSettings } from '../Hooks/useClientContext';
 import { PowerBIHome } from './PbiHome/PbiHome';
 import { Container, Content, Header, ViewportWrapper } from './clientHomeStyles';

--- a/src/Core/ConfirmationDialog/Components/ConfirmationDialog.tsx
+++ b/src/Core/ConfirmationDialog/Components/ConfirmationDialog.tsx
@@ -1,4 +1,4 @@
-import { Button, Dialog, Scrim } from '@equinor/eds-core-react';
+import { Button, Dialog, Scrim } from '@equinor/eds-core-react-old';
 import styled from 'styled-components';
 import { clearConfirmationDialog } from '../Functions/clearConfirmationDialog';
 import { useConfirmationDialog } from '../Hooks/useConfirmationDialog';

--- a/src/Core/ErrorBoundary/Components/ErrorFallback.tsx
+++ b/src/Core/ErrorBoundary/Components/ErrorFallback.tsx
@@ -1,4 +1,4 @@
-import { Button } from '@equinor/eds-core-react';
+import { Button } from '@equinor/eds-core-react-old';
 import { tokens } from '@equinor/eds-tokens';
 import styled from 'styled-components';
 import LogoIcon from '../../../icons/ProX_logo';

--- a/src/Core/ErrorBoundary/Components/ErrorFallbackSidesheet.tsx
+++ b/src/Core/ErrorBoundary/Components/ErrorFallbackSidesheet.tsx
@@ -1,4 +1,4 @@
-import { Button } from '@equinor/eds-core-react';
+import { Button } from '@equinor/eds-core-react-old';
 import { tokens } from '@equinor/eds-tokens';
 import styled from 'styled-components';
 import LogoIcon from '../../../icons/ProX_logo';

--- a/src/Core/GlobalSearh/Components/GlobalSearch.tsx
+++ b/src/Core/GlobalSearh/Components/GlobalSearch.tsx
@@ -1,4 +1,4 @@
-import { DotProgress } from '@equinor/eds-core-react';
+import { DotProgress } from '@equinor/eds-core-react-old';
 import { useCallback, useEffect, useRef, useState } from 'react';
 import { ArrowNavigation } from 'react-arrow-navigation';
 import { useNavigate } from 'react-router';

--- a/src/Core/GlobalSearh/Components/GlobalSearchStyles.ts
+++ b/src/Core/GlobalSearh/Components/GlobalSearchStyles.ts
@@ -1,4 +1,4 @@
-import { Search as EdsSearch } from '@equinor/eds-core-react';
+import { Search as EdsSearch } from '@equinor/eds-core-react-old';
 import { tokens } from '@equinor/eds-tokens';
 import styled from 'styled-components';
 

--- a/src/Core/GlobalSearh/Components/SearchResultHeadingStyles.ts
+++ b/src/Core/GlobalSearh/Components/SearchResultHeadingStyles.ts
@@ -1,4 +1,4 @@
-import { Typography } from '@equinor/eds-core-react';
+import { Typography } from '@equinor/eds-core-react-old';
 import styled from 'styled-components';
 
 export const Wrapper = styled.div`

--- a/src/Core/GlobalSearh/Components/SearchResultItemMenu.tsx
+++ b/src/Core/GlobalSearh/Components/SearchResultItemMenu.tsx
@@ -1,4 +1,4 @@
-import { Menu } from '@equinor/eds-core-react';
+import { Menu } from '@equinor/eds-core-react-old';
 import { Icon } from '@equinor/lighthouse-components';
 import { useState } from 'react';
 import { VerticalMenu } from './SearchResultItemStyles';

--- a/src/Core/GlobalSearh/Components/SearchResultItemStyles.ts
+++ b/src/Core/GlobalSearh/Components/SearchResultItemStyles.ts
@@ -1,4 +1,4 @@
-import { Typography } from '@equinor/eds-core-react';
+import { Typography } from '@equinor/eds-core-react-old';
 import { tokens } from '@equinor/eds-tokens';
 import styled from 'styled-components';
 

--- a/src/Core/GroupView/Components/GroupView/GroupView.tsx
+++ b/src/Core/GroupView/Components/GroupView/GroupView.tsx
@@ -1,4 +1,4 @@
-import { Icon } from '@equinor/eds-core-react';
+import { Icon } from '@equinor/eds-core-react-old';
 import { tokens } from '@equinor/eds-tokens';
 import { ErrorBoundary } from '@equinor/ErrorBoundary';
 import { AppGroupe, AppGroups, AppManifest } from '@equinor/lighthouse-portal-client';

--- a/src/Core/GroupView/Components/GroupView/GroupViewStyles.ts
+++ b/src/Core/GroupView/Components/GroupView/GroupViewStyles.ts
@@ -1,4 +1,4 @@
-import { Typography } from '@equinor/eds-core-react';
+import { Typography } from '@equinor/eds-core-react-old';
 import { tokens } from '@equinor/eds-tokens';
 import { Link as RouterLink } from 'react-router-dom';
 import styled from 'styled-components';

--- a/src/Core/GroupView/Components/Header/HeaderStyles.ts
+++ b/src/Core/GroupView/Components/Header/HeaderStyles.ts
@@ -1,4 +1,4 @@
-import { Typography } from '@equinor/eds-core-react';
+import { Typography } from '@equinor/eds-core-react-old';
 import { tokens } from '@equinor/eds-tokens';
 import styled from 'styled-components';
 

--- a/src/Core/Notifications/Components/NotificationBell.tsx
+++ b/src/Core/Notifications/Components/NotificationBell.tsx
@@ -1,4 +1,4 @@
-import { Icon } from '@equinor/eds-core-react';
+import { Icon } from '@equinor/eds-core-react-old';
 import { tokens } from '@equinor/eds-tokens';
 import { openSidesheetById } from '@equinor/sidesheet';
 import { useQueryClient } from 'react-query';

--- a/src/Core/PowerBiViewer/src/Components/PowerBiViewerHeader/PowerBiViewerHeaderStyles.ts
+++ b/src/Core/PowerBiViewer/src/Components/PowerBiViewerHeader/PowerBiViewerHeaderStyles.ts
@@ -1,4 +1,4 @@
-import { Tabs, Typography } from '@equinor/eds-core-react';
+import { Tabs, Typography } from '@equinor/eds-core-react-old';
 import { tokens } from '@equinor/eds-tokens';
 import styled from 'styled-components';
 

--- a/src/Core/WorkSpace/src/Components/DataLoadFailed/DumpsterFireDialog.tsx
+++ b/src/Core/WorkSpace/src/Components/DataLoadFailed/DumpsterFireDialog.tsx
@@ -1,4 +1,4 @@
-import { Dialog, Typography } from '@equinor/eds-core-react';
+import { Dialog, Typography } from '@equinor/eds-core-react-old';
 
 interface DumpsterFireDialogProps {
     title?: string;

--- a/src/Core/WorkSpace/src/Components/DataViewerHeader/CreatorButton/CreatorButton.tsx
+++ b/src/Core/WorkSpace/src/Components/DataViewerHeader/CreatorButton/CreatorButton.tsx
@@ -1,4 +1,4 @@
-import { Icon } from '@equinor/eds-core-react';
+import { Icon } from '@equinor/eds-core-react-old';
 import { tokens } from '@equinor/eds-tokens';
 import { useDataContext } from '../../../Context/DataProvider';
 import { TabButton } from '../../ToggleButton';

--- a/src/Core/WorkSpace/src/Components/DataViewerHeader/Header.tsx
+++ b/src/Core/WorkSpace/src/Components/DataViewerHeader/Header.tsx
@@ -6,7 +6,7 @@ import { PowerBiHeader } from './PowerBiHeader';
 import { WorkspaceHeader } from './WorkspaceHeader';
 import { useEffect } from 'react';
 import { spawnConfirmationDialog } from '../../../../ConfirmationDialog/Functions/spawnConfirmationDialog';
-import { CircularProgress } from '@equinor/eds-core-react';
+import { CircularProgress } from '@equinor/eds-core-react-old';
 import { useContactPerson } from '../../../../../hooks/useContactPerson';
 
 interface CompletionViewHeaderProps {

--- a/src/Core/WorkSpace/src/Components/DataViewerHeader/HeaderStyles.ts
+++ b/src/Core/WorkSpace/src/Components/DataViewerHeader/HeaderStyles.ts
@@ -1,4 +1,4 @@
-import { Tabs, Typography } from '@equinor/eds-core-react';
+import { Tabs, Typography } from '@equinor/eds-core-react-old';
 import { tokens } from '@equinor/eds-tokens';
 import styled from 'styled-components';
 

--- a/src/Core/WorkSpace/src/Components/DataViewerHeader/HeaderTabButtons/HeaderTabButtons.tsx
+++ b/src/Core/WorkSpace/src/Components/DataViewerHeader/HeaderTabButtons/HeaderTabButtons.tsx
@@ -1,4 +1,4 @@
-import { Icon } from '@equinor/eds-core-react';
+import { Icon } from '@equinor/eds-core-react-old';
 import { tokens } from '@equinor/eds-tokens';
 import { useLocationContext } from '../../../Context/LocationProvider';
 import { useViewerContext } from '../../../Context/ViewProvider';

--- a/src/Core/WorkSpace/src/Components/DataViewerHeader/PowerBiHeader.tsx
+++ b/src/Core/WorkSpace/src/Components/DataViewerHeader/PowerBiHeader.tsx
@@ -1,4 +1,4 @@
-import { Divider } from '@equinor/eds-core-react';
+import { Divider } from '@equinor/eds-core-react-old';
 import { TabsConfigItem } from '../../Util/tabsConfig';
 import { LeftSection, RightSection } from './HeaderStyles';
 import { HeaderTabButtons } from './HeaderTabButtons/HeaderTabButtons';

--- a/src/Core/WorkSpace/src/Components/DataViewerHeader/RefreshButton/RefreshButton.tsx
+++ b/src/Core/WorkSpace/src/Components/DataViewerHeader/RefreshButton/RefreshButton.tsx
@@ -1,4 +1,4 @@
-import { Button, CircularProgress } from '@equinor/eds-core-react';
+import { Button, CircularProgress } from '@equinor/eds-core-react-old';
 import { Case, Switch } from '@equinor/JSX-Switch';
 import { ClickableIcon } from '../../../../../../packages/Components/Icon';
 import { useDataContext } from '../../../Context/DataProvider';

--- a/src/Core/WorkSpace/src/Components/DataViewerHeader/ViewSettings/ViewSettings.tsx
+++ b/src/Core/WorkSpace/src/Components/DataViewerHeader/ViewSettings/ViewSettings.tsx
@@ -1,4 +1,4 @@
-import { Icon, Popover } from '@equinor/eds-core-react';
+import { Icon, Popover } from '@equinor/eds-core-react-old';
 import { tokens } from '@equinor/eds-tokens';
 import { useState, useRef, useMemo } from 'react';
 

--- a/src/Core/WorkSpace/src/Components/FallbackSidesheet/Fallback.tsx
+++ b/src/Core/WorkSpace/src/Components/FallbackSidesheet/Fallback.tsx
@@ -1,4 +1,4 @@
-import { Banner, Icon } from '@equinor/eds-core-react';
+import { Banner, Icon } from '@equinor/eds-core-react-old';
 import styled from 'styled-components';
 
 export const Fallback = (): JSX.Element => {

--- a/src/Core/WorkSpace/src/Components/Presets/Presets.tsx
+++ b/src/Core/WorkSpace/src/Components/Presets/Presets.tsx
@@ -1,5 +1,5 @@
 import { deref } from '@dbeining/react-atom';
-import { Chip } from '@equinor/eds-core-react';
+import { Chip } from '@equinor/eds-core-react-old';
 import { tokens } from '@equinor/eds-tokens';
 import { useFilterApiContext } from '@equinor/filter';
 import { useWorkSpace } from '@equinor/WorkSpace';

--- a/src/Core/WorkSpace/src/Components/QuickFilter/FilterGroup/FilterGroup.tsx
+++ b/src/Core/WorkSpace/src/Components/QuickFilter/FilterGroup/FilterGroup.tsx
@@ -1,4 +1,4 @@
-import { Icon } from '@equinor/eds-core-react';
+import { Icon } from '@equinor/eds-core-react-old';
 import { tokens } from '@equinor/eds-tokens';
 import { FilterValueType, useFilterApiContext } from '@equinor/filter';
 import { useRef } from 'react';

--- a/src/Core/WorkSpace/src/Components/QuickFilter/FilterGroup/FilterGroupPopoverMenu.tsx
+++ b/src/Core/WorkSpace/src/Components/QuickFilter/FilterGroup/FilterGroupPopoverMenu.tsx
@@ -1,4 +1,4 @@
-import { Menu, Button, Search } from '@equinor/eds-core-react';
+import { Menu, Button, Search } from '@equinor/eds-core-react-old';
 import { useState } from 'react';
 import styled from 'styled-components';
 import { useFilterApiContext } from '../../../../../../packages/Filter/Hooks/useFilterApiContext';

--- a/src/Core/WorkSpace/src/Components/QuickFilter/FilterItemCheckbox.tsx
+++ b/src/Core/WorkSpace/src/Components/QuickFilter/FilterItemCheckbox.tsx
@@ -1,5 +1,5 @@
 import { memo } from 'react';
-import { Checkbox } from '@equinor/eds-core-react';
+import { Checkbox } from '@equinor/eds-core-react-old';
 import { tokens } from '@equinor/eds-tokens';
 import { VirtualItem } from 'react-virtual';
 import styled from 'styled-components';

--- a/src/Core/WorkSpace/src/Components/QuickFilter/FilterQuickSearch.tsx
+++ b/src/Core/WorkSpace/src/Components/QuickFilter/FilterQuickSearch.tsx
@@ -1,4 +1,4 @@
-import { Search } from '@equinor/eds-core-react';
+import { Search } from '@equinor/eds-core-react-old';
 import { tokens } from '@equinor/eds-tokens';
 import { useState } from 'react';
 import styled from 'styled-components';
@@ -71,7 +71,7 @@ export const FilterQuickSearch = (): JSX.Element => {
     );
 };
 
-const EdsSearch = styled(Search) <{ hasValue: boolean }>`
+const EdsSearch = styled(Search)<{ hasValue: boolean }>`
     border: ${({ hasValue }) =>
         hasValue ? `1px solid ${tokens.colors.interactive.primary__resting.hex}` : 'none'};
 `;

--- a/src/Core/WorkSpace/src/Components/QuickFilter/Icons/FilterClear.tsx
+++ b/src/Core/WorkSpace/src/Components/QuickFilter/Icons/FilterClear.tsx
@@ -1,4 +1,4 @@
-import { Button } from '@equinor/eds-core-react';
+import { Button } from '@equinor/eds-core-react-old';
 import { tokens } from '@equinor/eds-tokens';
 
 interface FilterClearIconProps {

--- a/src/Core/WorkSpace/src/Components/QuickFilter/Icons/FilterCollapsIcon.tsx
+++ b/src/Core/WorkSpace/src/Components/QuickFilter/Icons/FilterCollapsIcon.tsx
@@ -1,4 +1,4 @@
-import { Button } from '@equinor/eds-core-react';
+import { Button } from '@equinor/eds-core-react-old';
 
 interface FilterCollapseIconProps {
     onClick?: (e: React.MouseEvent<HTMLButtonElement, MouseEvent>) => void;

--- a/src/Core/WorkSpace/src/Components/QuickFilter/Icons/FilterExpandIcon.tsx
+++ b/src/Core/WorkSpace/src/Components/QuickFilter/Icons/FilterExpandIcon.tsx
@@ -1,4 +1,4 @@
-import { Button } from '@equinor/eds-core-react';
+import { Button } from '@equinor/eds-core-react-old';
 
 interface FilterExpandIconProps {
     onClick?: (e: React.MouseEvent<HTMLButtonElement, MouseEvent>) => void;

--- a/src/Core/WorkSpace/src/Components/QuickFilter/QuickFilter.tsx
+++ b/src/Core/WorkSpace/src/Components/QuickFilter/QuickFilter.tsx
@@ -8,7 +8,7 @@ import { FilterCollapseIcon } from './Icons/FilterCollapsIcon';
 import { FilterExpandIcon } from './Icons/FilterExpandIcon';
 import { FilterClearIcon } from './Icons/FilterClear';
 import { CompactFilterWrapper, SearchLine, LeftSection, RightSection } from './quickFilterStyles';
-import { Chip } from '@equinor/eds-core-react';
+import { Chip } from '@equinor/eds-core-react-old';
 import styled from 'styled-components';
 import { tokens } from '@equinor/eds-tokens';
 import { useWorkSpace } from '@equinor/WorkSpace';

--- a/src/Core/WorkSpace/src/Components/QuickFilter/SearchPickerDropdown.tsx
+++ b/src/Core/WorkSpace/src/Components/QuickFilter/SearchPickerDropdown.tsx
@@ -1,4 +1,4 @@
-import { Menu } from '@equinor/eds-core-react';
+import { Menu } from '@equinor/eds-core-react-old';
 import { tokens } from '@equinor/eds-tokens';
 import { ClickableIcon } from '@equinor/lighthouse-components';
 import { useRef, useState } from 'react';

--- a/src/Core/WorkSpace/src/Components/QuickFilter/ToggleHideFilterPopover.tsx
+++ b/src/Core/WorkSpace/src/Components/QuickFilter/ToggleHideFilterPopover.tsx
@@ -1,4 +1,4 @@
-import { Button, Icon, Checkbox, Popover } from '@equinor/eds-core-react';
+import { Button, Icon, Checkbox, Popover } from '@equinor/eds-core-react-old';
 import { tokens } from '@equinor/eds-tokens';
 import { useState, useRef } from 'react';
 import { ReactSortable } from 'react-sortablejs';

--- a/src/Core/WorkSpace/src/Components/WorkSpace/WorkSpaceView.tsx
+++ b/src/Core/WorkSpace/src/Components/WorkSpace/WorkSpaceView.tsx
@@ -1,4 +1,4 @@
-import { Button, CircularProgress } from '@equinor/eds-core-react';
+import { Button, CircularProgress } from '@equinor/eds-core-react-old';
 import { PopoutSidesheet, useSideSheet } from '@equinor/sidesheet';
 import { useNavigate } from 'react-router';
 import styled from 'styled-components';

--- a/src/Core/WorkSpace/src/Icons/Admin.tsx
+++ b/src/Core/WorkSpace/src/Icons/Admin.tsx
@@ -1,3 +1,3 @@
-import { Icon } from '@equinor/eds-core-react';
+import { Icon } from '@equinor/eds-core-react-old';
 
 export const AdminIcon = (): JSX.Element => <Icon name="settings" />;

--- a/src/Core/WorkSpace/src/Icons/Help.tsx
+++ b/src/Core/WorkSpace/src/Icons/Help.tsx
@@ -1,3 +1,3 @@
-import { Icon } from '@equinor/eds-core-react';
+import { Icon } from '@equinor/eds-core-react-old';
 
 export const HelpPageIcon = (): JSX.Element => <Icon name="help" />;

--- a/src/Core/WorkSpace/src/Tabs/ListTab/ListTabPopover.tsx
+++ b/src/Core/WorkSpace/src/Tabs/ListTab/ListTabPopover.tsx
@@ -1,4 +1,4 @@
-import { Popover } from '@equinor/eds-core-react';
+import { Popover } from '@equinor/eds-core-react-old';
 import { ColumnMenuPicker, ExportToExcel } from '@equinor/Table';
 import { useWorkSpace } from '../..';
 import { tabApis } from '../../Context/LocationProvider';

--- a/src/apps/DisciplineReleaseControl/Components/3D/3dViewStyles.ts
+++ b/src/apps/DisciplineReleaseControl/Components/3D/3dViewStyles.ts
@@ -1,4 +1,4 @@
-import { Tabs } from '@equinor/eds-core-react';
+import { Tabs } from '@equinor/eds-core-react-old';
 import styled from 'styled-components';
 
 export const ThreeDModel = styled.div`

--- a/src/apps/DisciplineReleaseControl/Components/Form/Inputs/PhaseSelect.tsx
+++ b/src/apps/DisciplineReleaseControl/Components/Form/Inputs/PhaseSelect.tsx
@@ -1,4 +1,4 @@
-import { SingleSelect } from '@equinor/eds-core-react';
+import { SingleSelect } from '@equinor/eds-core-react-old';
 import { useQuery } from 'react-query';
 import { DRCFormAtomApi } from '../../../../ReleaseControl/Atoms/formAtomApi';
 import { releaseControlQueries } from '../../../../ReleaseControl/queries/queries';

--- a/src/apps/DisciplineReleaseControl/Components/MenuButton/Components/IconMenu.tsx
+++ b/src/apps/DisciplineReleaseControl/Components/MenuButton/Components/IconMenu.tsx
@@ -1,4 +1,4 @@
-import { Button, Icon, Menu, Typography } from '@equinor/eds-core-react';
+import { Button, Icon, Menu, Typography } from '@equinor/eds-core-react-old';
 import { tokens } from '@equinor/eds-tokens';
 import { useRef, useState } from 'react';
 import styled from 'styled-components';
@@ -53,7 +53,11 @@ export const IconMenu = ({ items, onMenuOpen }: IconMenuProps): JSX.Element => {
                 {items.map((x, i) => {
                     const Icon = () => x.icon ?? null;
                     return (
-                        <Menu.Item disabled={x.isDisabled} onClick={() => x.onClick && x.onClick()} key={x.label + i}>
+                        <Menu.Item
+                            disabled={x.isDisabled}
+                            onClick={() => x.onClick && x.onClick()}
+                            key={x.label + i}
+                        >
                             <Icon />
                             <MenuText>{x.label}</MenuText>
                         </Menu.Item>

--- a/src/apps/DisciplineReleaseControl/Components/MenuButton/Components/MenuButton.tsx
+++ b/src/apps/DisciplineReleaseControl/Components/MenuButton/Components/MenuButton.tsx
@@ -1,4 +1,4 @@
-import { Button, Icon, Menu, Typography } from '@equinor/eds-core-react';
+import { Button, Icon, Menu, Typography } from '@equinor/eds-core-react-old';
 import { useRef, useState } from 'react';
 import styled from 'styled-components';
 import { MenuItem } from '../Types/menuItem';

--- a/src/apps/DisciplineReleaseControl/Components/Sidesheet/ErrorBanner.tsx
+++ b/src/apps/DisciplineReleaseControl/Components/Sidesheet/ErrorBanner.tsx
@@ -1,4 +1,4 @@
-import { Banner, Button, Icon } from '@equinor/eds-core-react';
+import { Banner, Button, Icon } from '@equinor/eds-core-react-old';
 import { useIsMounted } from '@equinor/lighthouse-utils';
 import { useEffect, useState } from 'react';
 import styled from 'styled-components';

--- a/src/apps/DisciplineReleaseControl/Components/Sidesheet/ReleaseControlHTSidesheet.tsx
+++ b/src/apps/DisciplineReleaseControl/Components/Sidesheet/ReleaseControlHTSidesheet.tsx
@@ -1,4 +1,4 @@
-import { Tabs } from '@equinor/eds-core-react';
+import { Tabs } from '@equinor/eds-core-react-old';
 import { useLocationKey } from '@equinor/hooks';
 import { SidesheetApi } from '@equinor/sidesheet';
 import { useEffect, useState } from 'react';

--- a/src/apps/DisciplineReleaseControl/Components/Sidesheet/ReleaseControlSidesheet.tsx
+++ b/src/apps/DisciplineReleaseControl/Components/Sidesheet/ReleaseControlSidesheet.tsx
@@ -1,4 +1,4 @@
-import { Tabs } from '@equinor/eds-core-react';
+import { Tabs } from '@equinor/eds-core-react-old';
 import { useLocationKey } from '@equinor/hooks';
 import { ModelViewerContextProvider } from '@equinor/lighthouse-model-viewer';
 import { SidesheetApi } from '@equinor/sidesheet';

--- a/src/apps/DisciplineReleaseControl/Components/Sidesheet/WorkOrderTable.tsx
+++ b/src/apps/DisciplineReleaseControl/Components/Sidesheet/WorkOrderTable.tsx
@@ -1,4 +1,4 @@
-import { Button } from '@equinor/eds-core-react';
+import { Button } from '@equinor/eds-core-react-old';
 import { proCoSysUrls } from '@equinor/procosys-urls';
 import { Column, EstimateBar, ExpendedProgressBar, ProgressBar, Table } from '@equinor/Table';
 import styled from 'styled-components';

--- a/src/apps/DisciplineReleaseControl/Components/Sidesheet/sidesheetStyles.ts
+++ b/src/apps/DisciplineReleaseControl/Components/Sidesheet/sidesheetStyles.ts
@@ -1,4 +1,4 @@
-import { Tabs } from '@equinor/eds-core-react';
+import { Tabs } from '@equinor/eds-core-react-old';
 import { tokens } from '@equinor/eds-tokens';
 import styled from 'styled-components';
 

--- a/src/apps/DisciplineReleaseControl/Components/Sidesheet/useSidesheetEffects.tsx
+++ b/src/apps/DisciplineReleaseControl/Components/Sidesheet/useSidesheetEffects.tsx
@@ -1,4 +1,4 @@
-import { Icon } from '@equinor/eds-core-react';
+import { Icon } from '@equinor/eds-core-react-old';
 import { tokens } from '@equinor/eds-tokens';
 import { useEffect } from 'react';
 import { SidesheetApi } from '@equinor/sidesheet';

--- a/src/apps/DisciplineReleaseControl/Components/Workflow/Components/WorkflowIcon.tsx
+++ b/src/apps/DisciplineReleaseControl/Components/Workflow/Components/WorkflowIcon.tsx
@@ -1,4 +1,4 @@
-import { Icon } from '@equinor/eds-core-react';
+import { Icon } from '@equinor/eds-core-react-old';
 import { tokens } from '@equinor/eds-tokens';
 import styled from 'styled-components';
 

--- a/src/apps/Handover/Garden/CustomViews/HandoverGroupByView.tsx
+++ b/src/apps/Handover/Garden/CustomViews/HandoverGroupByView.tsx
@@ -1,4 +1,4 @@
-import { SingleSelect } from '@equinor/eds-core-react';
+import { SingleSelect } from '@equinor/eds-core-react-old';
 import { useParkViewContext } from '../../../../components/ParkView/Context/ParkViewProvider';
 import { HandoverCustomGroupByKeys } from '../models/handoverCustomGroupByKeys';
 

--- a/src/apps/Handover/Garden/components/HandoverSidesheet/HandoverSideSheet.tsx
+++ b/src/apps/Handover/Garden/components/HandoverSidesheet/HandoverSideSheet.tsx
@@ -1,4 +1,4 @@
-import { Tabs } from '@equinor/eds-core-react';
+import { Tabs } from '@equinor/eds-core-react-old';
 import { SideSheetContainer, SidesheetHeaderContent } from '@equinor/GardenUtils';
 import { isProduction } from '@equinor/lighthouse-portal-client';
 import { SidesheetApi } from '@equinor/sidesheet';

--- a/src/apps/Loop/components/LoopGroupBySelect.tsx
+++ b/src/apps/Loop/components/LoopGroupBySelect.tsx
@@ -1,4 +1,4 @@
-import { SingleSelect } from '@equinor/eds-core-react';
+import { SingleSelect } from '@equinor/eds-core-react-old';
 import { useParkViewContext } from '@equinor/ParkView';
 import { CustomGroupByKeys } from '../types';
 

--- a/src/apps/Loop/components/Sidesheet/3D/3dView.tsx
+++ b/src/apps/Loop/components/Sidesheet/3D/3dView.tsx
@@ -1,4 +1,4 @@
-import { CircularProgress } from '@equinor/eds-core-react';
+import { CircularProgress } from '@equinor/eds-core-react-old';
 import { tokens } from '@equinor/eds-tokens';
 import { generateExpressions, generateFamRequest } from '@equinor/fam-request-builder';
 import { Viewer } from '@equinor/lighthouse-model-viewer';

--- a/src/apps/Loop/components/Sidesheet/LoopSidesheet.tsx
+++ b/src/apps/Loop/components/Sidesheet/LoopSidesheet.tsx
@@ -1,4 +1,4 @@
-import { Tabs } from '@equinor/eds-core-react';
+import { Tabs } from '@equinor/eds-core-react-old';
 import { proCoSysUrls } from '@equinor/procosys-urls';
 import { useEffect, useState } from 'react';
 import { ModelViewerContextProvider } from '../../../../packages/ModelViewer/context/modelViewerContext';

--- a/src/apps/Loop/components/Sidesheet/TabTitle.tsx
+++ b/src/apps/Loop/components/Sidesheet/TabTitle.tsx
@@ -1,4 +1,4 @@
-import { Progress } from '@equinor/eds-core-react';
+import { Progress } from '@equinor/eds-core-react-old';
 
 type LoadingTabTitleProps<T> = {
     isLoading: boolean;

--- a/src/apps/Loop/components/Sidesheet/sidesheet-styles.ts
+++ b/src/apps/Loop/components/Sidesheet/sidesheet-styles.ts
@@ -1,4 +1,4 @@
-import { Tabs } from '@equinor/eds-core-react';
+import { Tabs } from '@equinor/eds-core-react-old';
 import { tokens } from '@equinor/eds-tokens';
 import styled from 'styled-components';
 

--- a/src/apps/MechanicalCompletion/components/McCustomGroupByView.tsx
+++ b/src/apps/MechanicalCompletion/components/McCustomGroupByView.tsx
@@ -1,4 +1,4 @@
-import { SingleSelect } from '@equinor/eds-core-react';
+import { SingleSelect } from '@equinor/eds-core-react-old';
 import { useParkViewContext } from '../../../components/ParkView/Context/ParkViewProvider';
 import { CustomGroupByKeys } from '../types';
 

--- a/src/apps/MechanicalCompletion/components/McSidesheet/McSideSheet.tsx
+++ b/src/apps/MechanicalCompletion/components/McSidesheet/McSideSheet.tsx
@@ -1,4 +1,4 @@
-import { Tabs } from '@equinor/eds-core-react';
+import { Tabs } from '@equinor/eds-core-react-old';
 import { SideSheetContainer, SidesheetHeaderContent } from '@equinor/GardenUtils';
 import { isProduction } from '@equinor/lighthouse-portal-client';
 import { SidesheetApi } from '@equinor/sidesheet';

--- a/src/apps/Punch/components/PunchGroupBySelect.tsx
+++ b/src/apps/Punch/components/PunchGroupBySelect.tsx
@@ -1,4 +1,4 @@
-import { SingleSelect } from '@equinor/eds-core-react';
+import { SingleSelect } from '@equinor/eds-core-react-old';
 import { useParkViewContext } from '@equinor/ParkView';
 import { CustomGroupByKeys } from '../types';
 

--- a/src/apps/Punch/components/PunchSidesheet/PunchSidesheet.tsx
+++ b/src/apps/Punch/components/PunchSidesheet/PunchSidesheet.tsx
@@ -1,4 +1,4 @@
-import { Tabs } from '@equinor/eds-core-react';
+import { Tabs } from '@equinor/eds-core-react-old';
 import { SideSheetContainer, SidesheetHeaderContent } from '@equinor/GardenUtils';
 import { proCoSysUrls } from '@equinor/procosys-urls';
 import { SidesheetApi } from '@equinor/sidesheet';

--- a/src/apps/Query/components/QuerySidesheet/QuerySidesheet.tsx
+++ b/src/apps/Query/components/QuerySidesheet/QuerySidesheet.tsx
@@ -1,4 +1,4 @@
-import { Tabs } from '@equinor/eds-core-react';
+import { Tabs } from '@equinor/eds-core-react-old';
 import { SideSheetContainer, SidesheetHeaderContent } from '@equinor/GardenUtils';
 import { proCoSysUrls } from '@equinor/procosys-urls';
 import { SidesheetApi } from '@equinor/sidesheet';

--- a/src/apps/ReleaseControl/components/Attachments/AttachmentVisual.tsx
+++ b/src/apps/ReleaseControl/components/Attachments/AttachmentVisual.tsx
@@ -1,4 +1,4 @@
-import { Icon } from '@equinor/eds-core-react';
+import { Icon } from '@equinor/eds-core-react-old';
 import { tokens } from '@equinor/eds-tokens';
 import { ClickableIcon } from '../../../../packages/Components/Icon';
 import { AttachmentVisualStyle } from './attachments.styles';

--- a/src/apps/ReleaseControl/components/Attachments/Attachments.tsx
+++ b/src/apps/ReleaseControl/components/Attachments/Attachments.tsx
@@ -1,5 +1,5 @@
 import { FileRejection, useDropzone } from 'react-dropzone';
-import { Icon, Progress } from '@equinor/eds-core-react';
+import { Icon, Progress } from '@equinor/eds-core-react-old';
 import { tokens } from '@equinor/eds-tokens';
 import {
     AttachmentsContainer,

--- a/src/apps/ReleaseControl/components/Attachments/HotUpload.tsx
+++ b/src/apps/ReleaseControl/components/Attachments/HotUpload.tsx
@@ -1,4 +1,4 @@
-import { Banner } from '@equinor/eds-core-react';
+import { Banner } from '@equinor/eds-core-react-old';
 import { useCallback, useState } from 'react';
 import { FileRejection } from 'react-dropzone';
 import { uploadAttachment } from '../../api/releaseControl/Request';

--- a/src/apps/ReleaseControl/components/Attachments/Upload.tsx
+++ b/src/apps/ReleaseControl/components/Attachments/Upload.tsx
@@ -1,4 +1,4 @@
-import { Icon } from '@equinor/eds-core-react';
+import { Icon } from '@equinor/eds-core-react-old';
 import { tokens } from '@equinor/eds-tokens';
 import { useCallback, useState } from 'react';
 import { FileRejection } from 'react-dropzone';

--- a/src/apps/ReleaseControl/components/Form/Inputs/Description/Description.tsx
+++ b/src/apps/ReleaseControl/components/Form/Inputs/Description/Description.tsx
@@ -1,4 +1,4 @@
-import { TextField } from '@equinor/eds-core-react';
+import { TextField } from '@equinor/eds-core-react-old';
 import { DRCFormAtomApi } from '../../../../Atoms/formAtomApi';
 
 const { updateAtom, useAtomState } = DRCFormAtomApi;

--- a/src/apps/ReleaseControl/components/Form/Inputs/PlannedDueDate/PlannedDueDate.tsx
+++ b/src/apps/ReleaseControl/components/Form/Inputs/PlannedDueDate/PlannedDueDate.tsx
@@ -1,4 +1,4 @@
-import { TextField } from '@equinor/eds-core-react';
+import { TextField } from '@equinor/eds-core-react-old';
 import moment from 'moment';
 import { DRCFormAtomApi } from '../../../../Atoms/formAtomApi';
 

--- a/src/apps/ReleaseControl/components/Form/Inputs/Scope/TagTable.tsx
+++ b/src/apps/ReleaseControl/components/Form/Inputs/Scope/TagTable.tsx
@@ -3,7 +3,7 @@ import { proCoSysUrls, stidUrls, echoUrls } from '@equinor/procosys-urls';
 import { CellProps, Column, Table, defaultGroupByFn } from '@equinor/Table';
 import styled from 'styled-components';
 import { RemoveTagCell } from './RemoveTagCell';
-import { Icon } from '@equinor/eds-core-react';
+import { Icon } from '@equinor/eds-core-react-old';
 import { LinkGroup } from './LinkGroup';
 import { RcScopeTag } from '../../../../types/releaseControl';
 import {

--- a/src/apps/ReleaseControl/components/Form/Inputs/Title/Title.tsx
+++ b/src/apps/ReleaseControl/components/Form/Inputs/Title/Title.tsx
@@ -1,4 +1,4 @@
-import { TextField } from '@equinor/eds-core-react';
+import { TextField } from '@equinor/eds-core-react-old';
 import { DRCFormAtomApi } from '../../../../Atoms/formAtomApi';
 
 const { updateAtom, useAtomState } = DRCFormAtomApi;

--- a/src/apps/ReleaseControl/components/Form/ReleaseControlProcessForm.tsx
+++ b/src/apps/ReleaseControl/components/Form/ReleaseControlProcessForm.tsx
@@ -1,4 +1,4 @@
-import { Button, Icon, Progress, SingleSelect } from '@equinor/eds-core-react';
+import { Button, Icon, Progress, SingleSelect } from '@equinor/eds-core-react-old';
 import { tokens } from '@equinor/eds-tokens';
 import { useEffect, useState } from 'react';
 import { useMutation, useQuery, useQueryClient } from 'react-query';

--- a/src/apps/ReleaseControl/components/Form/WorkflowEditor/WorkflowCustomEditor.tsx
+++ b/src/apps/ReleaseControl/components/Form/WorkflowEditor/WorkflowCustomEditor.tsx
@@ -6,7 +6,7 @@ import { DRCFormAtomApi } from '../../../Atoms/formAtomApi';
 import { ProCoSysQueries } from '../../../hooks/ProCoSysQueries';
 import { DraggableReleaseControlStep } from '../../../types/releaseControl';
 import { WorkflowStep } from './WorkflowStep';
-import { CircularProgress } from '@equinor/eds-core-react';
+import { CircularProgress } from '@equinor/eds-core-react-old';
 
 const workflowOwner = 'ReleaseControl';
 

--- a/src/apps/ReleaseControl/components/Form/WorkflowEditor/WorkflowEditorHelpers.tsx
+++ b/src/apps/ReleaseControl/components/Form/WorkflowEditor/WorkflowEditorHelpers.tsx
@@ -1,4 +1,4 @@
-import { Icon } from '@equinor/eds-core-react';
+import { Icon } from '@equinor/eds-core-react-old';
 import { DRCFormAtomApi } from '../../../Atoms/formAtomApi';
 import {
     CreateReleaseControlStepModel,

--- a/src/apps/ReleaseControl/components/Form/WorkflowEditor/WorkflowStep.tsx
+++ b/src/apps/ReleaseControl/components/Form/WorkflowEditor/WorkflowStep.tsx
@@ -1,4 +1,4 @@
-import { SingleSelect } from '@equinor/eds-core-react';
+import { SingleSelect } from '@equinor/eds-core-react-old';
 import { ClickableIcon } from '@equinor/lighthouse-components';
 import { IconMenu } from '@equinor/overlay-menu';
 import { FunctionalRole, PCSPersonRoleSearch, WorkflowStepTemplate } from '@equinor/Workflow';

--- a/src/apps/ReleaseControl/components/Form/releaseControlProcessForm.styles.ts
+++ b/src/apps/ReleaseControl/components/Form/releaseControlProcessForm.styles.ts
@@ -1,4 +1,4 @@
-import { Button } from '@equinor/eds-core-react';
+import { Button } from '@equinor/eds-core-react-old';
 import { tokens } from '@equinor/eds-tokens';
 import styled from 'styled-components';
 

--- a/src/apps/ReleaseControl/components/Workflow/Components/WorkflowIcon.tsx
+++ b/src/apps/ReleaseControl/components/Workflow/Components/WorkflowIcon.tsx
@@ -1,4 +1,4 @@
-import { Icon } from '@equinor/eds-core-react';
+import { Icon } from '@equinor/eds-core-react-old';
 import { tokens } from '@equinor/eds-tokens';
 import { DisputedWorkflowIcon } from '@equinor/Workflow';
 import styled from 'styled-components';

--- a/src/apps/ReleaseControl/components/Workflow/Contributor/Contributor.tsx
+++ b/src/apps/ReleaseControl/components/Workflow/Contributor/Contributor.tsx
@@ -1,4 +1,4 @@
-import { TextField, Button, Divider } from '@equinor/eds-core-react';
+import { TextField, Button, Divider } from '@equinor/eds-core-react-old';
 import { useState } from 'react';
 import { submitContribution } from '../../../api/releaseControl/Workflow';
 import { useReleaseControlContext } from '../../../hooks/useReleaseControlContext';

--- a/src/apps/ReleaseControl/components/Workflow/Contributor/ContributorActionbar.tsx
+++ b/src/apps/ReleaseControl/components/Workflow/Contributor/ContributorActionbar.tsx
@@ -1,4 +1,4 @@
-import { Icon } from '@equinor/eds-core-react';
+import { Icon } from '@equinor/eds-core-react-old';
 import { useQuery, useQueryClient } from 'react-query';
 
 import { ButtonContainer } from './contributor.styles';

--- a/src/apps/ReleaseControl/components/Workflow/Criteria/Components/AddContributor.tsx
+++ b/src/apps/ReleaseControl/components/Workflow/Criteria/Components/AddContributor.tsx
@@ -1,7 +1,7 @@
 import { useState } from 'react';
 import styled from 'styled-components';
 
-import { Button, TextField } from '@equinor/eds-core-react';
+import { Button, TextField } from '@equinor/eds-core-react-old';
 import { tokens } from '@equinor/eds-tokens';
 import { WorkflowIcon } from '../../Components/WorkflowIcon';
 import { releaseControlMutationKeys } from '../../../../queries/releaseControlMutationKeys';

--- a/src/apps/ReleaseControl/components/Workflow/Criteria/Components/Criteria.tsx
+++ b/src/apps/ReleaseControl/components/Workflow/Criteria/Components/Criteria.tsx
@@ -16,7 +16,7 @@ import { Contributor, Criteria } from '../../../../types/releaseControl';
 import { Modal } from '@equinor/modal';
 import { actionWithCommentAtom, SignWithCommentModal } from '@equinor/Workflow';
 import { useGetReleaseControl, useWorkflowSigning } from '../../../../hooks';
-import { CircularProgress } from '@equinor/eds-core-react';
+import { CircularProgress } from '@equinor/eds-core-react-old';
 
 interface CriteriaRenderProps {
     name: string;

--- a/src/apps/ReleaseControl/components/Workflow/Criteria/Components/CriteriaActionBar.tsx
+++ b/src/apps/ReleaseControl/components/Workflow/Criteria/Components/CriteriaActionBar.tsx
@@ -1,5 +1,5 @@
 import { swap } from '@dbeining/react-atom';
-import { Button, Icon, Progress } from '@equinor/eds-core-react';
+import { Button, Icon, Progress } from '@equinor/eds-core-react-old';
 import { tokens } from '@equinor/eds-tokens';
 import { useQuery } from 'react-query';
 import { IconMenu, MiniMenuButton, MenuItem } from '@equinor/overlay-menu';

--- a/src/apps/ReleaseControl/components/Workflow/Criteria/Components/CriteriaActionOverlay.tsx
+++ b/src/apps/ReleaseControl/components/Workflow/Criteria/Components/CriteriaActionOverlay.tsx
@@ -1,5 +1,5 @@
 import { useAtom } from '@dbeining/react-atom';
-import { Button } from '@equinor/eds-core-react';
+import { Button } from '@equinor/eds-core-react-old';
 import { ReassignBar } from '../../ReassignBar/ReassignBar';
 import styled from 'styled-components';
 import { useReleaseControlContext } from '../../../../hooks/useReleaseControlContext';

--- a/src/apps/ReleaseControl/components/sidesheet/ReleaseControlSidesheet/EditTabs/EditButtonBar.tsx
+++ b/src/apps/ReleaseControl/components/sidesheet/ReleaseControlSidesheet/EditTabs/EditButtonBar.tsx
@@ -1,4 +1,4 @@
-import { Button, Progress } from '@equinor/eds-core-react';
+import { Button, Progress } from '@equinor/eds-core-react-old';
 import { disableEditMode } from '../../../../Atoms/editModeAtom';
 import { DRCFormAtomApi } from '../../../../Atoms/formAtomApi';
 import {

--- a/src/apps/ReleaseControl/components/sidesheet/ReleaseControlSidesheet/ReleaseControlDetailView.tsx
+++ b/src/apps/ReleaseControl/components/sidesheet/ReleaseControlSidesheet/ReleaseControlDetailView.tsx
@@ -1,4 +1,4 @@
-import { Tabs } from '@equinor/eds-core-react';
+import { Tabs } from '@equinor/eds-core-react-old';
 import { useEdsTabs } from '@equinor/hooks';
 import { ReleaseControlSidesheetBanner } from './ReleaseControlSidesheetBanner';
 import { HeaderTab, SidesheetTabList, Tab, TabList } from './sidesheetStyles';

--- a/src/apps/ReleaseControl/components/sidesheet/ReleaseControlSidesheet/ReleaseControlRequestEditForm.tsx
+++ b/src/apps/ReleaseControl/components/sidesheet/ReleaseControlSidesheet/ReleaseControlRequestEditForm.tsx
@@ -2,7 +2,7 @@ import { useEffect } from 'react';
 import { useReleaseControlContext, useUnpackReferences } from '../../../hooks';
 import { ReleaseControlSidesheetBanner } from './ReleaseControlSidesheetBanner';
 import { HeaderTab, SidesheetTabList, Tab, TabList } from './sidesheetStyles';
-import { Tabs } from '@equinor/eds-core-react';
+import { Tabs } from '@equinor/eds-core-react-old';
 import { EditScopeTab } from './EditTabs/EditScopeTab';
 import { EditWorkflowTab } from './EditTabs/EditWorkflowTab';
 import { HistoryTab } from './Tabs/HistoryTab';

--- a/src/apps/ReleaseControl/components/sidesheet/ReleaseControlSidesheet/ReleaseControlSidesheetBanner.tsx
+++ b/src/apps/ReleaseControl/components/sidesheet/ReleaseControlSidesheet/ReleaseControlSidesheetBanner.tsx
@@ -1,4 +1,4 @@
-import { CircularProgress } from '@equinor/eds-core-react';
+import { CircularProgress } from '@equinor/eds-core-react-old';
 import { useIsReleaseControlMutatingOrFetching } from '../../../hooks';
 import { useReleaseControlContext } from '../../../hooks/useReleaseControlContext';
 import { Banner, BannerItemTitle, BannerItemValue, ChipText, SpinnerChip } from './sidesheetStyles';

--- a/src/apps/ReleaseControl/components/sidesheet/ReleaseControlSidesheet/Tabs/ScopeTab.tsx
+++ b/src/apps/ReleaseControl/components/sidesheet/ReleaseControlSidesheet/Tabs/ScopeTab.tsx
@@ -1,4 +1,4 @@
-import { CircularProgress } from '@equinor/eds-core-react';
+import { CircularProgress } from '@equinor/eds-core-react-old';
 import { useGetReleaseControl } from '../../../../hooks/useGetReleaseControl';
 import { useReleaseControlContext } from '../../../../hooks/useReleaseControlContext';
 import { Attachments } from '../../../Attachments/AttachmentsView';

--- a/src/apps/ReleaseControl/components/sidesheet/ReleaseControlSidesheet/sidesheetStyles.ts
+++ b/src/apps/ReleaseControl/components/sidesheet/ReleaseControlSidesheet/sidesheetStyles.ts
@@ -1,4 +1,4 @@
-import { Chip, Tabs } from '@equinor/eds-core-react';
+import { Chip, Tabs } from '@equinor/eds-core-react-old';
 import { tokens } from '@equinor/eds-tokens';
 import styled from 'styled-components';
 

--- a/src/apps/ReleaseControl/hooks/useSidesheetEffects.tsx
+++ b/src/apps/ReleaseControl/hooks/useSidesheetEffects.tsx
@@ -1,5 +1,5 @@
 import { deref, useAtom } from '@dbeining/react-atom';
-import { Icon } from '@equinor/eds-core-react';
+import { Icon } from '@equinor/eds-core-react-old';
 import { tokens } from '@equinor/eds-tokens';
 import { useEffect } from 'react';
 import { SidesheetApi } from '@equinor/sidesheet';

--- a/src/apps/ScopeChangeRequest/Components/AtsScopeCheckbox/AtsCheckbox.tsx
+++ b/src/apps/ScopeChangeRequest/Components/AtsScopeCheckbox/AtsCheckbox.tsx
@@ -1,4 +1,4 @@
-import { Checkbox } from '@equinor/eds-core-react';
+import { Checkbox } from '@equinor/eds-core-react-old';
 import styled from 'styled-components';
 import { useScopeChangeContext } from '../../hooks/context/useScopeChangeContext';
 

--- a/src/apps/ScopeChangeRequest/Components/Attachments/AttachmentVisual.tsx
+++ b/src/apps/ScopeChangeRequest/Components/Attachments/AttachmentVisual.tsx
@@ -1,4 +1,4 @@
-import { Icon } from '@equinor/eds-core-react';
+import { Icon } from '@equinor/eds-core-react-old';
 import { tokens } from '@equinor/eds-tokens';
 import styled from 'styled-components';
 import { ClickableIcon } from '../../../../packages/Components/Icon';

--- a/src/apps/ScopeChangeRequest/Components/Attachments/Attachments.tsx
+++ b/src/apps/ScopeChangeRequest/Components/Attachments/Attachments.tsx
@@ -1,5 +1,5 @@
 import { FileRejection, useDropzone } from 'react-dropzone';
-import { Icon, Progress } from '@equinor/eds-core-react';
+import { Icon, Progress } from '@equinor/eds-core-react-old';
 import { tokens } from '@equinor/eds-tokens';
 import styled from 'styled-components';
 

--- a/src/apps/ScopeChangeRequest/Components/Attachments/HotUpload.tsx
+++ b/src/apps/ScopeChangeRequest/Components/Attachments/HotUpload.tsx
@@ -1,4 +1,4 @@
-import { Banner } from '@equinor/eds-core-react';
+import { Banner } from '@equinor/eds-core-react-old';
 import { useCallback, useState } from 'react';
 import { FileRejection } from 'react-dropzone';
 import styled from 'styled-components';

--- a/src/apps/ScopeChangeRequest/Components/Attachments/RevisionAttachments.tsx
+++ b/src/apps/ScopeChangeRequest/Components/Attachments/RevisionAttachments.tsx
@@ -1,4 +1,4 @@
-import { Banner } from '@equinor/eds-core-react';
+import { Banner } from '@equinor/eds-core-react-old';
 import { useCallback, useState } from 'react';
 import { FileRejection } from 'react-dropzone';
 import styled from 'styled-components';

--- a/src/apps/ScopeChangeRequest/Components/Attachments/Upload.tsx
+++ b/src/apps/ScopeChangeRequest/Components/Attachments/Upload.tsx
@@ -1,4 +1,4 @@
-import { Icon } from '@equinor/eds-core-react';
+import { Icon } from '@equinor/eds-core-react-old';
 import { tokens } from '@equinor/eds-tokens';
 import { useCallback, useState } from 'react';
 import { FileRejection } from 'react-dropzone';

--- a/src/apps/ScopeChangeRequest/Components/DetailView/References.tsx
+++ b/src/apps/ScopeChangeRequest/Components/DetailView/References.tsx
@@ -16,7 +16,7 @@ import { System as SystemComp } from './RelatedObjects/Systems/System';
 import { StidDocument } from '../StidDocument/StidDocument';
 import { Punch } from './RelatedObjects/Punch/Punch';
 import { useState } from 'react';
-import { Icon } from '@equinor/eds-core-react';
+import { Icon } from '@equinor/eds-core-react-old';
 import { tokens } from '@equinor/eds-tokens';
 import { McPkg } from './RelatedObjects/McPkg/McPkg';
 import { getReferenceIcon } from '@equinor/Workflow';

--- a/src/apps/ScopeChangeRequest/Components/Form/DisciplineGuesstimate/DisciplineGuesstimate.tsx
+++ b/src/apps/ScopeChangeRequest/Components/Form/DisciplineGuesstimate/DisciplineGuesstimate.tsx
@@ -1,4 +1,4 @@
-import { Button, SingleSelect, TextField } from '@equinor/eds-core-react';
+import { Button, SingleSelect, TextField } from '@equinor/eds-core-react-old';
 import { useFacility } from '@equinor/lighthouse-portal-client';
 import { Discipline, proCoSysQueries } from '@equinor/Workflow';
 import { useQuery } from 'react-query';

--- a/src/apps/ScopeChangeRequest/Components/Form/EditFormActionBar.tsx
+++ b/src/apps/ScopeChangeRequest/Components/Form/EditFormActionBar.tsx
@@ -1,4 +1,4 @@
-import { Button, Progress } from '@equinor/eds-core-react';
+import { Button, Progress } from '@equinor/eds-core-react-old';
 import { disableEditMode } from '../../Atoms/editModeAtom';
 import { scopeChangeFormAtomApi } from '../../Atoms/FormAtomApi/formAtomApi';
 import { useScopeChangeContext } from '../../hooks/context/useScopeChangeContext';

--- a/src/apps/ScopeChangeRequest/Components/Form/Inputs/CategorySelect/CategorySelect.tsx
+++ b/src/apps/ScopeChangeRequest/Components/Form/Inputs/CategorySelect/CategorySelect.tsx
@@ -1,4 +1,4 @@
-import { SingleSelect } from '@equinor/eds-core-react';
+import { SingleSelect } from '@equinor/eds-core-react-old';
 import { useQuery } from 'react-query';
 
 import { scopeChangeFormAtomApi } from '../../../../Atoms/FormAtomApi/formAtomApi';

--- a/src/apps/ScopeChangeRequest/Components/Form/Inputs/MaterialsInput/MaterialsInput.tsx
+++ b/src/apps/ScopeChangeRequest/Components/Form/Inputs/MaterialsInput/MaterialsInput.tsx
@@ -1,4 +1,4 @@
-import { TextField } from '@equinor/eds-core-react';
+import { TextField } from '@equinor/eds-core-react-old';
 import { scopeChangeFormAtomApi } from '../../../../Atoms/FormAtomApi/formAtomApi';
 import { StyledCheckbox } from '../../StyledCheckbox/StyledCheckbox';
 

--- a/src/apps/ScopeChangeRequest/Components/Form/Inputs/OriginIdPicker/OriginIdPicker.tsx
+++ b/src/apps/ScopeChangeRequest/Components/Form/Inputs/OriginIdPicker/OriginIdPicker.tsx
@@ -3,7 +3,7 @@ import styled from 'styled-components';
 import { SearchOrigin } from './SearchOrigin';
 import { SelectPunch } from './SelectPunch';
 import { SelectSWCR } from './SelectSWCR';
-import { MultiSelect, TextField } from '@equinor/eds-core-react';
+import { MultiSelect, TextField } from '@equinor/eds-core-react-old';
 import { scopeChangeFormAtomApi } from '../../../../Atoms/FormAtomApi/formAtomApi';
 import { Case, Switch } from '@equinor/JSX-Switch';
 

--- a/src/apps/ScopeChangeRequest/Components/Form/Inputs/OriginIdPicker/SelectPunch.tsx
+++ b/src/apps/ScopeChangeRequest/Components/Form/Inputs/OriginIdPicker/SelectPunch.tsx
@@ -1,4 +1,4 @@
-import { CircularProgress, Icon, Input } from '@equinor/eds-core-react';
+import { CircularProgress, Icon, Input } from '@equinor/eds-core-react-old';
 import { tokens } from '@equinor/eds-tokens';
 import { validatePunch } from '@equinor/Workflow';
 import { useState } from 'react';

--- a/src/apps/ScopeChangeRequest/Components/Form/Inputs/OriginIdPicker/SelectSWCR.tsx
+++ b/src/apps/ScopeChangeRequest/Components/Form/Inputs/OriginIdPicker/SelectSWCR.tsx
@@ -1,4 +1,4 @@
-import { CircularProgress, Icon, Input } from '@equinor/eds-core-react';
+import { CircularProgress, Icon, Input } from '@equinor/eds-core-react-old';
 import { tokens } from '@equinor/eds-tokens';
 import { useCancellationToken } from '@equinor/hooks';
 import { useHttpClient } from '@equinor/lighthouse-portal-client';

--- a/src/apps/ScopeChangeRequest/Components/Form/Inputs/OriginSourceSelect/OriginSourceSelect.tsx
+++ b/src/apps/ScopeChangeRequest/Components/Form/Inputs/OriginSourceSelect/OriginSourceSelect.tsx
@@ -1,4 +1,4 @@
-import { SingleSelect } from '@equinor/eds-core-react';
+import { SingleSelect } from '@equinor/eds-core-react-old';
 import { scopeChangeFormAtomApi } from '../../../../Atoms/FormAtomApi/formAtomApi';
 import { OriginType } from '../../../../types/scopeChangeRequest';
 

--- a/src/apps/ScopeChangeRequest/Components/Form/Inputs/PhaseSelect/PhaseSelect.tsx
+++ b/src/apps/ScopeChangeRequest/Components/Form/Inputs/PhaseSelect/PhaseSelect.tsx
@@ -1,4 +1,4 @@
-import { SingleSelect } from '@equinor/eds-core-react';
+import { SingleSelect } from '@equinor/eds-core-react-old';
 import { useQuery } from 'react-query';
 import { scopeChangeFormAtomApi } from '../../../../Atoms/FormAtomApi/formAtomApi';
 import { scopeChangeQueries } from '../../../../keys/queries';

--- a/src/apps/ScopeChangeRequest/Components/Form/Inputs/ScopeSelect/ScopeSelect.tsx
+++ b/src/apps/ScopeChangeRequest/Components/Form/Inputs/ScopeSelect/ScopeSelect.tsx
@@ -1,4 +1,4 @@
-import { SingleSelect } from '@equinor/eds-core-react';
+import { SingleSelect } from '@equinor/eds-core-react-old';
 import { useQuery } from 'react-query';
 
 import { scopeChangeFormAtomApi } from '../../../../Atoms/FormAtomApi/formAtomApi';
@@ -24,8 +24,8 @@ export const ScopeSelect = (): JSX.Element => {
                 !change.selectedItem
                     ? updateAtom({ scope: null })
                     : updateAtom({
-                        scope: scopes?.find(({ name }) => name === change.selectedItem),
-                    });
+                          scope: scopes?.find(({ name }) => name === change.selectedItem),
+                      });
             }}
         />
     );

--- a/src/apps/ScopeChangeRequest/Components/Form/Inputs/TitleInput/TitleInput.tsx
+++ b/src/apps/ScopeChangeRequest/Components/Form/Inputs/TitleInput/TitleInput.tsx
@@ -1,4 +1,4 @@
-import { TextField } from '@equinor/eds-core-react';
+import { TextField } from '@equinor/eds-core-react-old';
 import { scopeChangeFormAtomApi } from '../../../../Atoms/FormAtomApi/formAtomApi';
 
 export const TitleInput = (): JSX.Element => {

--- a/src/apps/ScopeChangeRequest/Components/Form/ScopeChangeRequestForm.tsx
+++ b/src/apps/ScopeChangeRequest/Components/Form/ScopeChangeRequestForm.tsx
@@ -1,4 +1,4 @@
-import { Button, Progress } from '@equinor/eds-core-react';
+import { Button, Progress } from '@equinor/eds-core-react-old';
 import { useMutation, useQueryClient } from 'react-query';
 import styled from 'styled-components';
 import { getScopeChangeById } from '../../api/ScopeChange/Request';

--- a/src/apps/ScopeChangeRequest/Components/Form/StyledCheckbox/StyledCheckbox.tsx
+++ b/src/apps/ScopeChangeRequest/Components/Form/StyledCheckbox/StyledCheckbox.tsx
@@ -1,4 +1,4 @@
-import { Checkbox } from '@equinor/eds-core-react';
+import { Checkbox } from '@equinor/eds-core-react-old';
 import styled from 'styled-components';
 
 interface StyledCheckboxProps {

--- a/src/apps/ScopeChangeRequest/Components/Sidesheet/SidesheetWrapper/Loading.tsx
+++ b/src/apps/ScopeChangeRequest/Components/Sidesheet/SidesheetWrapper/Loading.tsx
@@ -1,4 +1,4 @@
-import { Progress } from '@equinor/eds-core-react';
+import { Progress } from '@equinor/eds-core-react-old';
 import styled from 'styled-components';
 
 const LoadingContainer = styled.div`

--- a/src/apps/ScopeChangeRequest/Components/Sidesheet/SidesheetWrapper/RevisionModal.tsx
+++ b/src/apps/ScopeChangeRequest/Components/Sidesheet/SidesheetWrapper/RevisionModal.tsx
@@ -1,4 +1,4 @@
-import { Button, TextField } from '@equinor/eds-core-react';
+import { Button, TextField } from '@equinor/eds-core-react-old';
 import React, { useState } from 'react';
 import { useMutation } from 'react-query';
 import styled from 'styled-components';

--- a/src/apps/ScopeChangeRequest/Components/Sidesheet/SidesheetWrapper/RevisionSubmitBar.tsx
+++ b/src/apps/ScopeChangeRequest/Components/Sidesheet/SidesheetWrapper/RevisionSubmitBar.tsx
@@ -1,4 +1,4 @@
-import { Button } from '@equinor/eds-core-react';
+import { Button } from '@equinor/eds-core-react-old';
 import { Modal } from '@equinor/modal';
 import { useState } from 'react';
 

--- a/src/apps/ScopeChangeRequest/Components/Sidesheet/SidesheetWrapper/ScopeChangeDetailView.tsx
+++ b/src/apps/ScopeChangeRequest/Components/Sidesheet/SidesheetWrapper/ScopeChangeDetailView.tsx
@@ -1,4 +1,4 @@
-import { Tabs } from '@equinor/eds-core-react';
+import { Tabs } from '@equinor/eds-core-react-old';
 import { useEdsTabs } from '@equinor/hooks';
 import styled from 'styled-components';
 import { SidesheetBanner } from '../SidesheetBanner/SidesheetBanner';

--- a/src/apps/ScopeChangeRequest/Components/Sidesheet/SidesheetWrapper/SidesheetWrapper.styles.ts
+++ b/src/apps/ScopeChangeRequest/Components/Sidesheet/SidesheetWrapper/SidesheetWrapper.styles.ts
@@ -1,4 +1,4 @@
-import { Tabs } from '@equinor/eds-core-react';
+import { Tabs } from '@equinor/eds-core-react-old';
 import { tokens } from '@equinor/eds-tokens';
 import styled from 'styled-components';
 

--- a/src/apps/ScopeChangeRequest/Components/Sidesheet/SidesheetWrapper/VoidRequest.tsx
+++ b/src/apps/ScopeChangeRequest/Components/Sidesheet/SidesheetWrapper/VoidRequest.tsx
@@ -1,4 +1,4 @@
-import { Button, TextField } from '@equinor/eds-core-react';
+import { Button, TextField } from '@equinor/eds-core-react-old';
 import { Modal } from '@equinor/modal';
 import { useState } from 'react';
 import styled from 'styled-components';

--- a/src/apps/ScopeChangeRequest/Components/Sidesheet/Tabs/Log/LogTabTitle.tsx
+++ b/src/apps/ScopeChangeRequest/Components/Sidesheet/Tabs/Log/LogTabTitle.tsx
@@ -1,4 +1,4 @@
-import { CircularProgress } from '@equinor/eds-core-react';
+import { CircularProgress } from '@equinor/eds-core-react-old';
 import { useIsFetching } from 'react-query';
 import styled from 'styled-components';
 import { scopeChangeQueries } from '../../../../keys/queries';

--- a/src/apps/ScopeChangeRequest/Components/Sidesheet/Tabs/Request/RequestTab.tsx
+++ b/src/apps/ScopeChangeRequest/Components/Sidesheet/Tabs/Request/RequestTab.tsx
@@ -20,7 +20,7 @@ import { Workflow } from '../../../Workflow/Workflow';
 import { WarrantyCaseDetailCheckbox } from '../../../WarrantyCaseDetailCheckbox/WarrantyCaseDetailCheckbox';
 import { GuesstimateDisciplineDetails } from '../../GuesstimateDisciplineDetails/GuesstimateDisciplineDetails';
 import { OriginLink } from '../../../DetailView/OriginLink';
-import { Checkbox } from '@equinor/eds-core-react';
+import { Checkbox } from '@equinor/eds-core-react-old';
 import { CheckboxWrapper } from '../../../WarrantyCaseDetailCheckbox/warrantyCaseDetailCheckbox.styles';
 import { RevisionsList } from './RevisionList/RevisionList';
 import { AtsDetailCheckbox } from '../../../AtsScopeCheckbox/AtsCheckbox';

--- a/src/apps/ScopeChangeRequest/Components/Sidesheet/Tabs/Request/RequestTabTitle.tsx
+++ b/src/apps/ScopeChangeRequest/Components/Sidesheet/Tabs/Request/RequestTabTitle.tsx
@@ -1,4 +1,4 @@
-import { CircularProgress } from '@equinor/eds-core-react';
+import { CircularProgress } from '@equinor/eds-core-react-old';
 import styled from 'styled-components';
 import { useIsScopeChangeMutatingOrFetching } from '../../../../hooks/observers/useIsScopeChangeMutatingOrFetching';
 import { useScopeChangeContext } from '../../../../hooks/context/useScopeChangeContext';

--- a/src/apps/ScopeChangeRequest/Components/Sidesheet/Tabs/WorkOrders/WorkOrderTabTitle.tsx
+++ b/src/apps/ScopeChangeRequest/Components/Sidesheet/Tabs/WorkOrders/WorkOrderTabTitle.tsx
@@ -1,4 +1,4 @@
-import { CircularProgress } from '@equinor/eds-core-react';
+import { CircularProgress } from '@equinor/eds-core-react-old';
 import { useIsFetching } from 'react-query';
 import styled from 'styled-components';
 

--- a/src/apps/ScopeChangeRequest/Components/WarrantyCaseDetailCheckbox/WarrantyCaseDetailCheckbox.tsx
+++ b/src/apps/ScopeChangeRequest/Components/WarrantyCaseDetailCheckbox/WarrantyCaseDetailCheckbox.tsx
@@ -1,4 +1,4 @@
-import { Checkbox } from '@equinor/eds-core-react';
+import { Checkbox } from '@equinor/eds-core-react-old';
 import { useScopeChangeContext } from '../../hooks/context/useScopeChangeContext';
 import { CheckboxWrapper } from './warrantyCaseDetailCheckbox.styles';
 

--- a/src/apps/ScopeChangeRequest/Components/Workflow/Components/WorkflowIcon.tsx
+++ b/src/apps/ScopeChangeRequest/Components/Workflow/Components/WorkflowIcon.tsx
@@ -1,4 +1,4 @@
-import { Icon } from '@equinor/eds-core-react';
+import { Icon } from '@equinor/eds-core-react-old';
 import { tokens } from '@equinor/eds-tokens';
 import { DisputedWorkflowIcon } from '@equinor/Workflow';
 import styled from 'styled-components';

--- a/src/apps/ScopeChangeRequest/Components/Workflow/Contributor/Contributor.tsx
+++ b/src/apps/ScopeChangeRequest/Components/Workflow/Contributor/Contributor.tsx
@@ -1,4 +1,4 @@
-import { TextField, Button, Divider } from '@equinor/eds-core-react';
+import { TextField, Button, Divider } from '@equinor/eds-core-react-old';
 import { useState } from 'react';
 import { submitContribution } from '../../../api/ScopeChange/Workflow';
 import { WorkflowIcon } from '../Components/WorkflowIcon';

--- a/src/apps/ScopeChangeRequest/Components/Workflow/Contributor/ContributorActionbar.tsx
+++ b/src/apps/ScopeChangeRequest/Components/Workflow/Contributor/ContributorActionbar.tsx
@@ -1,4 +1,4 @@
-import { Icon } from '@equinor/eds-core-react';
+import { Icon } from '@equinor/eds-core-react-old';
 import { useQuery, useQueryClient } from 'react-query';
 
 import { removeContributor } from '../../../api/ScopeChange/Workflow/removeContributor';

--- a/src/apps/ScopeChangeRequest/Components/Workflow/Criteria/Components/AddContributor.tsx
+++ b/src/apps/ScopeChangeRequest/Components/Workflow/Criteria/Components/AddContributor.tsx
@@ -2,7 +2,7 @@ import { useState } from 'react';
 import styled from 'styled-components';
 
 import { addContributor } from '../../../../api/ScopeChange/Workflow/addContributor';
-import { Button, TextField } from '@equinor/eds-core-react';
+import { Button, TextField } from '@equinor/eds-core-react-old';
 import { tokens } from '@equinor/eds-tokens';
 import { WorkflowIcon } from '../../Components/WorkflowIcon';
 import { useScopeChangeMutation } from '../../../../hooks/React-Query/useScopechangeMutation';

--- a/src/apps/ScopeChangeRequest/Components/Workflow/Criteria/Components/CriteriaActionBar.tsx
+++ b/src/apps/ScopeChangeRequest/Components/Workflow/Criteria/Components/CriteriaActionBar.tsx
@@ -1,5 +1,5 @@
 import { swap } from '@dbeining/react-atom';
-import { Button, Icon, Progress } from '@equinor/eds-core-react';
+import { Button, Icon, Progress } from '@equinor/eds-core-react-old';
 import { tokens } from '@equinor/eds-tokens';
 import { useQuery } from 'react-query';
 

--- a/src/apps/ScopeChangeRequest/Components/Workflow/Criteria/Components/CriteriaActionOverlay.tsx
+++ b/src/apps/ScopeChangeRequest/Components/Workflow/Criteria/Components/CriteriaActionOverlay.tsx
@@ -1,5 +1,5 @@
 import { useAtom } from '@dbeining/react-atom';
-import { Button } from '@equinor/eds-core-react';
+import { Button } from '@equinor/eds-core-react-old';
 import { useScopeChangeContext } from '../../../../hooks/context/useScopeChangeContext';
 import { ReassignBar } from '../../ReassignBar/ReassignBar';
 import styled from 'styled-components';

--- a/src/apps/ScopeChangeRequest/hooks/sidesheet/useSidesheetEffects.tsx
+++ b/src/apps/ScopeChangeRequest/hooks/sidesheet/useSidesheetEffects.tsx
@@ -1,5 +1,5 @@
 import { deref, useAtom } from '@dbeining/react-atom';
-import { Icon } from '@equinor/eds-core-react';
+import { Icon } from '@equinor/eds-core-react-old';
 import { tokens } from '@equinor/eds-tokens';
 import { MenuItem } from '@equinor/overlay-menu';
 import { SidesheetApi } from '@equinor/sidesheet';

--- a/src/apps/ScopeChangeRequest/workspaceConfig/sTable/Cells/Comments.tsx
+++ b/src/apps/ScopeChangeRequest/workspaceConfig/sTable/Cells/Comments.tsx
@@ -1,4 +1,4 @@
-import { Icon } from '@equinor/eds-core-react';
+import { Icon } from '@equinor/eds-core-react-old';
 import { tokens } from '@equinor/eds-tokens';
 import { CenterIcon } from './cells.styles';
 

--- a/src/apps/ScopeChangeRequest/workspaceConfig/sTable/Cells/PendingContributions.tsx
+++ b/src/apps/ScopeChangeRequest/workspaceConfig/sTable/Cells/PendingContributions.tsx
@@ -1,4 +1,4 @@
-import { Icon } from '@equinor/eds-core-react';
+import { Icon } from '@equinor/eds-core-react-old';
 import { tokens } from '@equinor/eds-tokens';
 import { CenterIcon } from './cells.styles';
 

--- a/src/apps/Tags/Components/Header.tsx
+++ b/src/apps/Tags/Components/Header.tsx
@@ -1,4 +1,4 @@
-import { Button, Icon } from '@equinor/eds-core-react';
+import { Button, Icon } from '@equinor/eds-core-react-old';
 import { tokens } from '@equinor/eds-tokens';
 import styled from 'styled-components';
 

--- a/src/apps/Tags/Components/TagsDetails.tsx
+++ b/src/apps/Tags/Components/TagsDetails.tsx
@@ -1,4 +1,4 @@
-import { Tabs, Typography } from '@equinor/eds-core-react';
+import { Tabs, Typography } from '@equinor/eds-core-react-old';
 import { proCoSysUrls } from '@equinor/procosys-urls';
 import { SidesheetApi } from '@equinor/sidesheet';
 import { useEffect, useRef, useState } from 'react';

--- a/src/apps/Tags/Components/sidesheet-styles.ts
+++ b/src/apps/Tags/Components/sidesheet-styles.ts
@@ -1,4 +1,4 @@
-import { Tabs } from '@equinor/eds-core-react';
+import { Tabs } from '@equinor/eds-core-react-old';
 import { tokens } from '@equinor/eds-tokens';
 import styled from 'styled-components';
 

--- a/src/apps/WorkOrder/Garden/components/WorkOrderSidesheet/Tabs/3dView.tsx
+++ b/src/apps/WorkOrder/Garden/components/WorkOrderSidesheet/Tabs/3dView.tsx
@@ -1,4 +1,4 @@
-import { CircularProgress } from '@equinor/eds-core-react';
+import { CircularProgress } from '@equinor/eds-core-react-old';
 import { tokens } from '@equinor/eds-tokens';
 import { statusColorMap } from '@equinor/GardenUtils';
 import { Viewer } from '@equinor/lighthouse-model-viewer';

--- a/src/apps/WorkOrder/Garden/components/WorkOrderSidesheet/Tabs/Cells/AvailableItemCell.tsx
+++ b/src/apps/WorkOrder/Garden/components/WorkOrderSidesheet/Tabs/Cells/AvailableItemCell.tsx
@@ -1,6 +1,6 @@
 import { CellProps } from '@equinor/Table';
 import { WorkOrderMaterial } from '../../../../models';
-import { Tooltip, Icon } from '@equinor/eds-core-react';
+import { Tooltip, Icon } from '@equinor/eds-core-react-old';
 
 export const AvailableItemCell = (props: CellProps<WorkOrderMaterial, WorkOrderMaterial>) => {
     const { value } = props;

--- a/src/apps/WorkOrder/Garden/components/WorkOrderSidesheet/WorkOrderSidesheet.tsx
+++ b/src/apps/WorkOrder/Garden/components/WorkOrderSidesheet/WorkOrderSidesheet.tsx
@@ -1,4 +1,4 @@
-import { Progress, Tabs } from '@equinor/eds-core-react';
+import { Progress, Tabs } from '@equinor/eds-core-react-old';
 import { SideSheetContainer, SidesheetHeaderContent } from '@equinor/GardenUtils';
 import { proCoSysUrls } from '@equinor/procosys-urls';
 import { SidesheetApi } from '@equinor/sidesheet';

--- a/src/apps/swcr/CustomViews/SwcrSideSheet.tsx
+++ b/src/apps/swcr/CustomViews/SwcrSideSheet.tsx
@@ -1,4 +1,4 @@
-import { Chip } from '@equinor/eds-core-react';
+import { Chip } from '@equinor/eds-core-react-old';
 import { SidesheetHeaderContent } from '@equinor/GardenUtils';
 import { SidesheetApi } from '@equinor/sidesheet';
 import { Fragment, useEffect } from 'react';
@@ -6,7 +6,6 @@ import styled from 'styled-components';
 import { isProduction } from '../../../Core/Client/Functions';
 import useSignatures from '../hooks/useSignatures';
 import { SwcrPackage } from '../models/SwcrPackage';
-
 
 const SideSheetContainer = styled.div`
     display: flex;

--- a/src/components/ActionCenter/ActionCenterSidesheet.tsx
+++ b/src/components/ActionCenter/ActionCenterSidesheet.tsx
@@ -1,4 +1,4 @@
-import { Tabs } from '@equinor/eds-core-react';
+import { Tabs } from '@equinor/eds-core-react-old';
 import { ComponentManifest, WidgetManifest } from '@equinor/lighthouse-widgets';
 import { SidesheetApi } from '@equinor/sidesheet';
 import { useEffect, useState } from 'react';

--- a/src/components/ActionCenter/GroupedAssignments.tsx
+++ b/src/components/ActionCenter/GroupedAssignments.tsx
@@ -1,4 +1,4 @@
-import { Accordion } from '@equinor/eds-core-react';
+import { Accordion } from '@equinor/eds-core-react-old';
 import { tokens } from '@equinor/eds-tokens';
 import styled from 'styled-components';
 import { AssignmentCard } from '../../Core/Assignments/Components/AssignmentsCard';

--- a/src/components/ActionCenter/NotificationsTab.tsx
+++ b/src/components/ActionCenter/NotificationsTab.tsx
@@ -1,4 +1,4 @@
-import { Chip } from '@equinor/eds-core-react';
+import { Chip } from '@equinor/eds-core-react-old';
 import { tokens } from '@equinor/eds-tokens';
 import { useState } from 'react';
 import { useQueryClient } from 'react-query';

--- a/src/components/Icon/ClickableIcon.tsx
+++ b/src/components/Icon/ClickableIcon.tsx
@@ -1,4 +1,4 @@
-import { Icon } from '@equinor/eds-core-react';
+import { Icon } from '@equinor/eds-core-react-old';
 import { tokens } from '@equinor/eds-tokens';
 
 export interface ClickableIconProps {

--- a/src/components/Icon/Icon.tsx
+++ b/src/components/Icon/Icon.tsx
@@ -1,4 +1,4 @@
-import { Icon as EdsIcon } from '@equinor/eds-core-react';
+import { Icon as EdsIcon } from '@equinor/eds-core-react-old';
 import * as icons from '@equinor/eds-icons';
 
 EdsIcon.add({ ...icons });

--- a/src/components/Menu/Components/CompactMenu/CompactMenu.tsx
+++ b/src/components/Menu/Components/CompactMenu/CompactMenu.tsx
@@ -1,4 +1,4 @@
-import { Button, Divider } from '@equinor/eds-core-react';
+import { Button, Divider } from '@equinor/eds-core-react-old';
 import { useClientContext } from '@equinor/lighthouse-portal-client';
 import { useMemo } from 'react';
 import { useLocation } from 'react-router';

--- a/src/components/Menu/Components/ExpandedMenu/ExpandedMenu.tsx
+++ b/src/components/Menu/Components/ExpandedMenu/ExpandedMenu.tsx
@@ -1,4 +1,4 @@
-import { Button, Icon, Search } from '@equinor/eds-core-react';
+import { Button, Icon, Search } from '@equinor/eds-core-react-old';
 import { useClientContext } from '@equinor/lighthouse-portal-client';
 import { useMemo, useState } from 'react';
 import { useMenuContext } from '../../Context/MenuContext';

--- a/src/components/Menu/Components/ExpandedMenu/ExpandedMenuStyles.ts
+++ b/src/components/Menu/Components/ExpandedMenu/ExpandedMenuStyles.ts
@@ -1,4 +1,4 @@
-import { Scrim } from '@equinor/eds-core-react';
+import { Scrim } from '@equinor/eds-core-react-old';
 import { tokens } from '@equinor/eds-tokens';
 import { Link as ReactLink } from 'react-router-dom';
 import styled from 'styled-components';

--- a/src/components/Menu/Components/Favourites/Favourites.tsx
+++ b/src/components/Menu/Components/Favourites/Favourites.tsx
@@ -1,4 +1,4 @@
-import { Accordion } from '@equinor/eds-core-react';
+import { Accordion } from '@equinor/eds-core-react-old';
 import { useClientContext } from '@equinor/lighthouse-portal-client';
 import { useMemo } from 'react';
 import Icon from '../../../Icon/Icon';

--- a/src/components/Menu/Components/Favourites/FavouritesStyles.ts
+++ b/src/components/Menu/Components/Favourites/FavouritesStyles.ts
@@ -1,4 +1,4 @@
-import { Accordion } from '@equinor/eds-core-react';
+import { Accordion } from '@equinor/eds-core-react-old';
 import { tokens } from '@equinor/eds-tokens';
 import styled from 'styled-components';
 

--- a/src/components/Menu/Components/MenuItem/MenuItemStyles.ts
+++ b/src/components/Menu/Components/MenuItem/MenuItemStyles.ts
@@ -1,4 +1,4 @@
-import { Typography } from '@equinor/eds-core-react';
+import { Typography } from '@equinor/eds-core-react-old';
 import { tokens } from '@equinor/eds-tokens';
 import styled from 'styled-components';
 interface MenuItemProps {

--- a/src/components/Messages/Service/Components/ServiceMessageBanner.tsx
+++ b/src/components/Messages/Service/Components/ServiceMessageBanner.tsx
@@ -1,4 +1,4 @@
-import { Button } from '@equinor/eds-core-react';
+import { Button } from '@equinor/eds-core-react-old';
 import { tokens } from '@equinor/eds-tokens';
 import Icon from '../../../Icon/Icon';
 import { ServiceMessage } from '../Types/serviceMessage';

--- a/src/components/Messages/Service/Components/ServiceMessageBannerStyles.ts
+++ b/src/components/Messages/Service/Components/ServiceMessageBannerStyles.ts
@@ -1,4 +1,4 @@
-import { Banner as EDSBanner } from '@equinor/eds-core-react';
+import { Banner as EDSBanner } from '@equinor/eds-core-react-old';
 import { tokens } from '@equinor/eds-tokens';
 import styled from 'styled-components';
 interface BannerProps {

--- a/src/components/Messages/Service/Components/ServiceMessagePost.tsx
+++ b/src/components/Messages/Service/Components/ServiceMessagePost.tsx
@@ -1,4 +1,4 @@
-import { Button, Scrim } from '@equinor/eds-core-react';
+import { Button, Scrim } from '@equinor/eds-core-react-old';
 import { GeneratedForm, useForm } from '@equinor/Form';
 import { useHttpClient } from '@equinor/lighthouse-portal-client';
 import { storage } from '@equinor/lighthouse-utils';

--- a/src/components/OverlayMenu/src/components/ButtonMenu/ButtonMenu.tsx
+++ b/src/components/OverlayMenu/src/components/ButtonMenu/ButtonMenu.tsx
@@ -1,4 +1,4 @@
-import { Button, Icon, Menu } from '@equinor/eds-core-react';
+import { Button, Icon, Menu } from '@equinor/eds-core-react-old';
 import { useRef, useState } from 'react';
 import { MenuItem } from '../../types/menuItem';
 import { MenuText, Wrapper } from './buttonMenu.styles';

--- a/src/components/OverlayMenu/src/components/ButtonMenu/MiniButtonMenu.tsx
+++ b/src/components/OverlayMenu/src/components/ButtonMenu/MiniButtonMenu.tsx
@@ -1,4 +1,4 @@
-import { Button, Icon, Menu } from '@equinor/eds-core-react';
+import { Button, Icon, Menu } from '@equinor/eds-core-react-old';
 import { useRef, useState } from 'react';
 import { MenuItem } from '../../types/menuItem';
 import { MenuText, MiniWrapper } from './buttonMenu.styles';

--- a/src/components/OverlayMenu/src/components/ButtonMenu/buttonMenu.styles.ts
+++ b/src/components/OverlayMenu/src/components/ButtonMenu/buttonMenu.styles.ts
@@ -1,4 +1,4 @@
-import { Typography } from '@equinor/eds-core-react';
+import { Typography } from '@equinor/eds-core-react-old';
 import styled from 'styled-components';
 
 export const Wrapper = styled.div`

--- a/src/components/OverlayMenu/src/components/IconMenu/IconMenu.tsx
+++ b/src/components/OverlayMenu/src/components/IconMenu/IconMenu.tsx
@@ -1,4 +1,4 @@
-import { Button, Icon, Menu } from '@equinor/eds-core-react';
+import { Button, Icon, Menu } from '@equinor/eds-core-react-old';
 import { tokens } from '@equinor/eds-tokens';
 import { useRef, useState } from 'react';
 import { MenuItem } from '../../types/menuItem';

--- a/src/components/OverlayMenu/src/components/IconMenu/iconMenu.styles.ts
+++ b/src/components/OverlayMenu/src/components/IconMenu/iconMenu.styles.ts
@@ -1,4 +1,4 @@
-import { Typography } from '@equinor/eds-core-react';
+import { Typography } from '@equinor/eds-core-react-old';
 import styled from 'styled-components';
 
 export const Wrapper = styled.div`

--- a/src/components/ParkView/Components/GroupBySelectors/ActiveGroupings.tsx
+++ b/src/components/ParkView/Components/GroupBySelectors/ActiveGroupings.tsx
@@ -1,4 +1,4 @@
-import { SingleSelect } from '@equinor/eds-core-react';
+import { SingleSelect } from '@equinor/eds-core-react-old';
 import { Fragment, useCallback } from 'react';
 import { useParkViewContext } from '../../Context/ParkViewProvider';
 import { SelectOneWrapper, Separator } from './groupBy.styles';

--- a/src/components/ParkView/Components/GroupBySelectors/InitialGroupBy.tsx
+++ b/src/components/ParkView/Components/GroupBySelectors/InitialGroupBy.tsx
@@ -1,4 +1,4 @@
-import { SingleSelect } from '@equinor/eds-core-react';
+import { SingleSelect } from '@equinor/eds-core-react-old';
 import { useCallback } from 'react';
 import { useParkViewContext } from '../../Context/ParkViewProvider';
 import { SelectOneWrapper } from './groupBy.styles';

--- a/src/components/ParkView/Components/GroupBySelectors/NextGroupBy.tsx
+++ b/src/components/ParkView/Components/GroupBySelectors/NextGroupBy.tsx
@@ -1,4 +1,4 @@
-import { SingleSelect } from '@equinor/eds-core-react';
+import { SingleSelect } from '@equinor/eds-core-react-old';
 import { useCallback } from 'react';
 import { useParkViewContext } from '../../Context/ParkViewProvider';
 import { SelectOneWrapper } from './groupBy.styles';

--- a/src/components/ParkView/Icons/Chevron.tsx
+++ b/src/components/ParkView/Icons/Chevron.tsx
@@ -1,4 +1,4 @@
-import { Icon } from '@equinor/eds-core-react';
+import { Icon } from '@equinor/eds-core-react-old';
 import { tokens } from '@equinor/eds-tokens';
 
 export const ChevronUp = (): JSX.Element => (

--- a/src/components/Routes/GroupComponentWrapper.tsx
+++ b/src/components/Routes/GroupComponentWrapper.tsx
@@ -1,4 +1,4 @@
-import { Icon } from '@equinor/eds-core-react';
+import { Icon } from '@equinor/eds-core-react-old';
 import { tokens } from '@equinor/eds-tokens';
 import { AppGroupe, AppManifest } from '@equinor/lighthouse-portal-client';
 import { Link } from 'react-router-dom';

--- a/src/components/TopBar/BreadCrumbs/Breadcrumbs.tsx
+++ b/src/components/TopBar/BreadCrumbs/Breadcrumbs.tsx
@@ -1,4 +1,4 @@
-import { Breadcrumbs } from '@equinor/eds-core-react';
+import { Breadcrumbs } from '@equinor/eds-core-react-old';
 import { Fragment, useCallback } from 'react';
 import { useLocation, useNavigate } from 'react-router';
 import { Link } from 'react-router-dom';

--- a/src/components/TopBar/HelpMenu.tsx
+++ b/src/components/TopBar/HelpMenu.tsx
@@ -1,4 +1,4 @@
-import { Icon, Popover, Typography } from '@equinor/eds-core-react';
+import { Icon, Popover, Typography } from '@equinor/eds-core-react-old';
 import { useLocationKey } from '@equinor/hooks';
 import { ClickableIcon } from '@equinor/lighthouse-components';
 import { useState, useRef, useMemo } from 'react';

--- a/src/components/TopBar/TopBar.tsx
+++ b/src/components/TopBar/TopBar.tsx
@@ -1,5 +1,5 @@
 import { BookmarkSidesheet } from '@equinor/BookmarksManager';
-import { TopBar } from '@equinor/eds-core-react';
+import { TopBar } from '@equinor/eds-core-react-old';
 import { tokens } from '@equinor/eds-tokens';
 import { ErrorBoundary } from '@equinor/ErrorBoundary';
 import { useClientContext } from '@equinor/lighthouse-portal-client';

--- a/src/components/TopBar/TopBarAvatar.tsx
+++ b/src/components/TopBar/TopBarAvatar.tsx
@@ -1,4 +1,4 @@
-import { Avatar, Icon, Popover } from '@equinor/eds-core-react';
+import { Avatar, Icon, Popover } from '@equinor/eds-core-react-old';
 import { tokens } from '@equinor/eds-tokens';
 import { useHttpClient } from '@equinor/lighthouse-portal-client';
 import { useRef, useState } from 'react';

--- a/src/components/TopBar/TopBarStyle.ts
+++ b/src/components/TopBar/TopBarStyle.ts
@@ -1,4 +1,4 @@
-import { TopBar } from '@equinor/eds-core-react';
+import { TopBar } from '@equinor/eds-core-react-old';
 import { tokens } from '@equinor/eds-tokens';
 import styled from 'styled-components';
 

--- a/src/fusion-framework/AppLoaderWrapper.tsx
+++ b/src/fusion-framework/AppLoaderWrapper.tsx
@@ -8,7 +8,7 @@ import {
     useBookmarkMutations,
 } from '../packages/BookmarksManager/src';
 import { useFusionBookmarks } from '../hooks/useFusionBookmarks';
-import { Button, CircularProgress, Typography } from '@equinor/eds-core-react';
+import { Button, CircularProgress, Typography } from '@equinor/eds-core-react-old';
 import styled from 'styled-components';
 import { useCurrentUser } from '@equinor/lighthouse-portal-client';
 

--- a/src/fusion-framework/ErrorViewer.tsx
+++ b/src/fusion-framework/ErrorViewer.tsx
@@ -1,4 +1,4 @@
-import { Typography } from '@equinor/eds-core-react';
+import { Typography } from '@equinor/eds-core-react-old';
 
 export const ErrorViewer = ({ error }: { readonly error: Error }) => {
     return (

--- a/src/icons/Asset data icon.tsx
+++ b/src/icons/Asset data icon.tsx
@@ -1,4 +1,4 @@
-import { Icon } from '@equinor/eds-core-react';
+import { Icon } from '@equinor/eds-core-react-old';
 import { tokens } from '@equinor/eds-tokens';
 
 export const AssetDataIcon = (): JSX.Element => {

--- a/src/icons/Collaboration icon.tsx
+++ b/src/icons/Collaboration icon.tsx
@@ -1,4 +1,4 @@
-import { Icon } from '@equinor/eds-core-react';
+import { Icon } from '@equinor/eds-core-react-old';
 import { tokens } from '@equinor/eds-tokens';
 
 export const CollaborationIcon = (): JSX.Element => {

--- a/src/icons/Engineering management icon.tsx
+++ b/src/icons/Engineering management icon.tsx
@@ -1,4 +1,4 @@
-import { Icon } from '@equinor/eds-core-react';
+import { Icon } from '@equinor/eds-core-react-old';
 import { tokens } from '@equinor/eds-tokens';
 
 export const EngineeringManagementIcon = (): JSX.Element => {

--- a/src/icons/Home icon.tsx
+++ b/src/icons/Home icon.tsx
@@ -1,4 +1,4 @@
-import { Icon } from '@equinor/eds-core-react';
+import { Icon } from '@equinor/eds-core-react-old';
 import { tokens } from '@equinor/eds-tokens';
 
 export const HomeIcon = (): JSX.Element => {

--- a/src/icons/ProjectInformationIcon.tsx
+++ b/src/icons/ProjectInformationIcon.tsx
@@ -1,4 +1,4 @@
-import { Icon } from '@equinor/eds-core-react';
+import { Icon } from '@equinor/eds-core-react-old';
 import { tokens } from '@equinor/eds-tokens';
 
 export const ProjectInformationIcon = (): JSX.Element => {

--- a/src/icons/Quality icon.tsx
+++ b/src/icons/Quality icon.tsx
@@ -1,4 +1,4 @@
-import { Icon } from '@equinor/eds-core-react';
+import { Icon } from '@equinor/eds-core-react-old';
 import { tokens } from '@equinor/eds-tokens';
 
 export const QualityIcon = (): JSX.Element => {

--- a/src/icons/Queries and requests icon.tsx
+++ b/src/icons/Queries and requests icon.tsx
@@ -1,4 +1,4 @@
-import { Icon } from '@equinor/eds-core-react';
+import { Icon } from '@equinor/eds-core-react-old';
 import { tokens } from '@equinor/eds-tokens';
 
 export const QueriesAndRequests = (): JSX.Element => {

--- a/src/icons/Report icon.tsx
+++ b/src/icons/Report icon.tsx
@@ -1,4 +1,4 @@
-import { Icon } from '@equinor/eds-core-react';
+import { Icon } from '@equinor/eds-core-react-old';
 import { tokens } from '@equinor/eds-tokens';
 
 export const ReportIcon = (): JSX.Element => {

--- a/src/icons/SSUIcon.tsx
+++ b/src/icons/SSUIcon.tsx
@@ -1,4 +1,4 @@
-import { Icon } from '@equinor/eds-core-react';
+import { Icon } from '@equinor/eds-core-react-old';
 import { tokens } from '@equinor/eds-tokens';
 
 export const SSUIcon = (): JSX.Element => {

--- a/src/icons/Scope and change icon.tsx
+++ b/src/icons/Scope and change icon.tsx
@@ -1,4 +1,4 @@
-import { Icon } from '@equinor/eds-core-react';
+import { Icon } from '@equinor/eds-core-react-old';
 import { tokens } from '@equinor/eds-tokens';
 
 export const ProjectControlIcon = (): JSX.Element => {

--- a/src/icons/construction management icon.tsx
+++ b/src/icons/construction management icon.tsx
@@ -1,4 +1,4 @@
-import { Icon } from '@equinor/eds-core-react';
+import { Icon } from '@equinor/eds-core-react-old';
 import { tokens } from '@equinor/eds-tokens';
 
 export const ConstructionManagementIcon = (): JSX.Element => {

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -1,4 +1,4 @@
-import { Icon as EdsIcon } from '@equinor/eds-core-react';
+import { Icon as EdsIcon } from '@equinor/eds-core-react-old';
 import * as icons from '@equinor/eds-icons';
 import { render } from 'react-dom';
 import { Bootstrap } from './AppClient';

--- a/src/modules/powerBI/src/Components/Filter/ExpandedFilter/FilterItems/Header/Header.tsx
+++ b/src/modules/powerBI/src/Components/Filter/ExpandedFilter/FilterItems/Header/Header.tsx
@@ -1,4 +1,4 @@
-import { Icon, Search } from '@equinor/eds-core-react';
+import { Icon, Search } from '@equinor/eds-core-react-old';
 import { Case, Switch } from '@equinor/JSX-Switch';
 import { ChangeEvent, useCallback } from 'react';
 import { FilterClearIcon } from '../../../FilterClearIcon';

--- a/src/modules/powerBI/src/Components/Filter/ExpandedFilter/FilterItems/Header/Styles.tsx
+++ b/src/modules/powerBI/src/Components/Filter/ExpandedFilter/FilterItems/Header/Styles.tsx
@@ -1,4 +1,4 @@
-import { Button } from '@equinor/eds-core-react';
+import { Button } from '@equinor/eds-core-react-old';
 import styled from 'styled-components';
 
 export const Container = styled.div`

--- a/src/modules/powerBI/src/Components/Filter/ExpandedFilter/FilterItems/Item.tsx
+++ b/src/modules/powerBI/src/Components/Filter/ExpandedFilter/FilterItems/Item.tsx
@@ -1,4 +1,4 @@
-import { Checkbox } from '@equinor/eds-core-react';
+import { Checkbox } from '@equinor/eds-core-react-old';
 import { memo, useMemo } from 'react';
 import { ActiveFilter, PowerBiFilter, PowerBiFilterItem } from '../../../../Types';
 import { IS_BLANK } from '../../../../Utils';

--- a/src/modules/powerBI/src/Components/Filter/FilterClearIcon.tsx
+++ b/src/modules/powerBI/src/Components/Filter/FilterClearIcon.tsx
@@ -1,4 +1,4 @@
-import { Button } from '@equinor/eds-core-react';
+import { Button } from '@equinor/eds-core-react-old';
 import { tokens } from '@equinor/eds-tokens';
 
 interface FilterClearIconProps {

--- a/src/modules/powerBI/src/Components/Filter/FilterGroup/FilterGroup.tsx
+++ b/src/modules/powerBI/src/Components/Filter/FilterGroup/FilterGroup.tsx
@@ -1,4 +1,4 @@
-import { Icon } from '@equinor/eds-core-react';
+import { Icon } from '@equinor/eds-core-react-old';
 import { tokens } from '@equinor/eds-tokens';
 import { useState, useRef } from 'react';
 import { getFilterHeaderText } from '../../../../../../Core/WorkSpace/src/Components/QuickFilter/FilterGroup/FilterGroup';

--- a/src/modules/powerBI/src/Components/Filter/PopoverGroup/PopoverGroup.tsx
+++ b/src/modules/powerBI/src/Components/Filter/PopoverGroup/PopoverGroup.tsx
@@ -1,4 +1,4 @@
-import { Menu, Button, Search } from '@equinor/eds-core-react';
+import { Menu, Button, Search } from '@equinor/eds-core-react-old';
 import { Switch, Case } from '@equinor/JSX-Switch';
 import { EventHub } from '@equinor/lighthouse-utils';
 import { useState, useCallback, useMemo, useEffect } from 'react';

--- a/src/modules/powerBI/src/Components/Filter/PowerBiQuickFilter.tsx
+++ b/src/modules/powerBI/src/Components/Filter/PowerBiQuickFilter.tsx
@@ -1,4 +1,4 @@
-import { Chip } from '@equinor/eds-core-react';
+import { Chip } from '@equinor/eds-core-react-old';
 import { tokens } from '@equinor/eds-tokens';
 import styled from 'styled-components';
 import { FilterClearIcon } from '../../../../../Core/WorkSpace/src/Components/QuickFilter/Icons/FilterClear';

--- a/src/modules/powerBI/src/Components/Filter/Styles.tsx
+++ b/src/modules/powerBI/src/Components/Filter/Styles.tsx
@@ -1,4 +1,4 @@
-import { Button } from '@equinor/eds-core-react';
+import { Button } from '@equinor/eds-core-react-old';
 import { tokens } from '@equinor/eds-tokens';
 import styled from 'styled-components';
 

--- a/src/modules/powerBI/src/Components/ReportErrorMessage/ReportErrorMessage.tsx
+++ b/src/modules/powerBI/src/Components/ReportErrorMessage/ReportErrorMessage.tsx
@@ -1,4 +1,4 @@
-import { Accordion } from '@equinor/eds-core-react';
+import { Accordion } from '@equinor/eds-core-react-old';
 import { tokens } from '@equinor/eds-tokens';
 import { Icon, MarkdownViewer } from '@equinor/lighthouse-components';
 import { FC } from 'react';
@@ -9,7 +9,7 @@ import {
     ErrorWrapper,
     Heading,
     HeadingWrapper,
-    RequirementsWrapper
+    RequirementsWrapper,
 } from './ReportErrorMessageStyles';
 
 interface ReportErrorMessageProps {

--- a/src/modules/powerBI/src/Components/ReportErrorMessage/ReportErrorMessageStyles.ts
+++ b/src/modules/powerBI/src/Components/ReportErrorMessage/ReportErrorMessageStyles.ts
@@ -1,4 +1,4 @@
-import { Accordion, Card } from '@equinor/eds-core-react';
+import { Accordion, Card } from '@equinor/eds-core-react-old';
 import { tokens } from '@equinor/eds-tokens';
 import styled from 'styled-components';
 

--- a/src/packages/Admin/src/Components/Form/Inputs/StepCompletedStatusSelect.tsx
+++ b/src/packages/Admin/src/Components/Form/Inputs/StepCompletedStatusSelect.tsx
@@ -1,4 +1,4 @@
-import { SingleSelect } from '@equinor/eds-core-react';
+import { SingleSelect } from '@equinor/eds-core-react-old';
 import { useQuery } from 'react-query';
 import { WorkflowStepAdminAtomApi } from '../../../Atoms/workflowStepAdminAtomApi';
 import { useAdminContext } from '../../../Hooks/useAdminContext';

--- a/src/packages/Admin/src/Components/Form/Inputs/StepDescriptionInput.tsx
+++ b/src/packages/Admin/src/Components/Form/Inputs/StepDescriptionInput.tsx
@@ -1,4 +1,4 @@
-import { TextField } from '@equinor/eds-core-react';
+import { TextField } from '@equinor/eds-core-react-old';
 import { WorkflowStepAdminAtomApi } from '../../../Atoms/workflowStepAdminAtomApi';
 
 const { updateAtom } = WorkflowStepAdminAtomApi;

--- a/src/packages/Admin/src/Components/Form/Inputs/StepRejectedStatusSelect.tsx
+++ b/src/packages/Admin/src/Components/Form/Inputs/StepRejectedStatusSelect.tsx
@@ -1,4 +1,4 @@
-import { SingleSelect } from '@equinor/eds-core-react';
+import { SingleSelect } from '@equinor/eds-core-react-old';
 import { useQuery } from 'react-query';
 import { WorkflowStepAdminAtomApi } from '../../../Atoms/workflowStepAdminAtomApi';
 import { useAdminContext } from '../../../Hooks/useAdminContext';

--- a/src/packages/Admin/src/Components/Modal/CreateStatusModal.tsx
+++ b/src/packages/Admin/src/Components/Modal/CreateStatusModal.tsx
@@ -1,4 +1,4 @@
-import { Button, TextField } from '@equinor/eds-core-react';
+import { Button, TextField } from '@equinor/eds-core-react-old';
 import { KeyboardEventHandler, useState } from 'react';
 import { useAdminContext } from '../../Hooks/useAdminContext';
 import { useAdminMutation } from '../../Hooks/useAdminMutation';

--- a/src/packages/Admin/src/Components/Modal/CreateStepModal.tsx
+++ b/src/packages/Admin/src/Components/Modal/CreateStepModal.tsx
@@ -1,4 +1,4 @@
-import { Button, TextField } from '@equinor/eds-core-react';
+import { Button, TextField } from '@equinor/eds-core-react-old';
 import { KeyboardEventHandler, useState } from 'react';
 import { openWorkflowStepSidesheet } from '../Workspace/WorkflowSteps';
 import { ModalButtonContainer, ModalInputContainer } from './modalStyles';

--- a/src/packages/Admin/src/Components/Modal/CreateWorkflowModal.tsx
+++ b/src/packages/Admin/src/Components/Modal/CreateWorkflowModal.tsx
@@ -1,4 +1,4 @@
-import { Button, TextField } from '@equinor/eds-core-react';
+import { Button, TextField } from '@equinor/eds-core-react-old';
 import { KeyboardEventHandler, useState } from 'react';
 import { useAdminContext } from '../../Hooks/useAdminContext';
 import { useAdminMutation } from '../../Hooks/useAdminMutation';

--- a/src/packages/Admin/src/Components/Modal/DeleteWorkflowModal.tsx
+++ b/src/packages/Admin/src/Components/Modal/DeleteWorkflowModal.tsx
@@ -1,4 +1,4 @@
-import { Button } from '@equinor/eds-core-react';
+import { Button } from '@equinor/eds-core-react-old';
 import { Workflow, WorkflowStatus, WorkflowStepTemplate } from '@equinor/Workflow';
 import { updateContext } from '../../Atoms/updateContext';
 import { useAdminContext } from '../../Hooks/useAdminContext';

--- a/src/packages/Admin/src/Components/Modal/DeleteWorkflowStatusModal.tsx
+++ b/src/packages/Admin/src/Components/Modal/DeleteWorkflowStatusModal.tsx
@@ -1,4 +1,4 @@
-import { Button } from '@equinor/eds-core-react';
+import { Button } from '@equinor/eds-core-react-old';
 import { Workflow, WorkflowStatus, WorkflowStepTemplate } from '@equinor/Workflow';
 import { updateContext } from '../../Atoms/updateContext';
 import { useAdminContext } from '../../Hooks/useAdminContext';

--- a/src/packages/Admin/src/Components/Modal/DeleteWorkflowStepModal.tsx
+++ b/src/packages/Admin/src/Components/Modal/DeleteWorkflowStepModal.tsx
@@ -1,4 +1,4 @@
-import { Button } from '@equinor/eds-core-react';
+import { Button } from '@equinor/eds-core-react-old';
 import { Workflow, WorkflowStatus, WorkflowStepTemplate } from '@equinor/Workflow';
 import { updateContext } from '../../Atoms/updateContext';
 import { useAdminContext } from '../../Hooks/useAdminContext';

--- a/src/packages/Admin/src/Components/Modal/EditStatusModal.tsx
+++ b/src/packages/Admin/src/Components/Modal/EditStatusModal.tsx
@@ -1,4 +1,4 @@
-import { Button, TextField } from '@equinor/eds-core-react';
+import { Button, TextField } from '@equinor/eds-core-react-old';
 import { Workflow, WorkflowStepTemplate } from '@equinor/Workflow';
 import { KeyboardEventHandler, useState } from 'react';
 import { updateContext } from '../../Atoms/updateContext';

--- a/src/packages/Admin/src/Components/Modal/EditStepModal.tsx
+++ b/src/packages/Admin/src/Components/Modal/EditStepModal.tsx
@@ -1,4 +1,4 @@
-import { Button, TextField } from '@equinor/eds-core-react';
+import { Button, TextField } from '@equinor/eds-core-react-old';
 import { Workflow, WorkflowStatus, WorkflowStepTemplate } from '@equinor/Workflow';
 import { KeyboardEventHandler, useState } from 'react';
 import { useMutation } from 'react-query';

--- a/src/packages/Admin/src/Components/Modal/EditWorkflowModal.tsx
+++ b/src/packages/Admin/src/Components/Modal/EditWorkflowModal.tsx
@@ -1,4 +1,4 @@
-import { Button, TextField } from '@equinor/eds-core-react';
+import { Button, TextField } from '@equinor/eds-core-react-old';
 import { WorkflowStatus, WorkflowStepTemplate } from '@equinor/Workflow';
 import { KeyboardEventHandler, useState } from 'react';
 import { updateContext } from '../../Atoms/updateContext';

--- a/src/packages/Admin/src/Components/Sidesheet/WorkflowCreateButtonBar.tsx
+++ b/src/packages/Admin/src/Components/Sidesheet/WorkflowCreateButtonBar.tsx
@@ -1,4 +1,4 @@
-import { Button, Progress } from '@equinor/eds-core-react';
+import { Button, Progress } from '@equinor/eds-core-react-old';
 import { SidesheetApi } from '@equinor/sidesheet';
 import { useMutation } from 'react-query';
 import { WorkflowAdminAtomApi } from '../../Atoms/workflowAdminAtomApi';

--- a/src/packages/Admin/src/Components/Sidesheet/WorkflowSaveButtonBar.tsx
+++ b/src/packages/Admin/src/Components/Sidesheet/WorkflowSaveButtonBar.tsx
@@ -1,4 +1,4 @@
-import { Button, Progress } from '@equinor/eds-core-react';
+import { Button, Progress } from '@equinor/eds-core-react-old';
 import { SidesheetApi } from '@equinor/sidesheet';
 import { WorkflowAdminAtomApi } from '../../Atoms/workflowAdminAtomApi';
 import { useAdminContext } from '../../Hooks/useAdminContext';

--- a/src/packages/Admin/src/Components/Sidesheet/WorkflowSidesheet.tsx
+++ b/src/packages/Admin/src/Components/Sidesheet/WorkflowSidesheet.tsx
@@ -28,7 +28,7 @@ import { WorkflowSaveButtonBar } from './WorkflowSaveButtonBar';
 import { WorkflowCreateButtonBar } from './WorkflowCreateButtonBar';
 import { useAdminMutationWatcher } from '../../Hooks/useAdminMutationWatcher';
 import { useIsTemplateLoading } from '../../Hooks/useIsTemplateLoading';
-import { Button, Progress } from '@equinor/eds-core-react';
+import { Button, Progress } from '@equinor/eds-core-react-old';
 
 interface WorkflowSidesheetProps {
     item: Workflow;

--- a/src/packages/Admin/src/Components/Sidesheet/WorkflowStepCreateButtonBar.tsx
+++ b/src/packages/Admin/src/Components/Sidesheet/WorkflowStepCreateButtonBar.tsx
@@ -1,4 +1,4 @@
-import { Button, Progress } from '@equinor/eds-core-react';
+import { Button, Progress } from '@equinor/eds-core-react-old';
 import { SidesheetApi } from '@equinor/sidesheet';
 import { useMutation } from 'react-query';
 import { WorkflowStepAdminAtomApi } from '../../Atoms/workflowStepAdminAtomApi';

--- a/src/packages/Admin/src/Components/Sidesheet/WorkflowStepSaveButtonBar.tsx
+++ b/src/packages/Admin/src/Components/Sidesheet/WorkflowStepSaveButtonBar.tsx
@@ -1,4 +1,4 @@
-import { Button, Progress } from '@equinor/eds-core-react';
+import { Button, Progress } from '@equinor/eds-core-react-old';
 import { SidesheetApi } from '@equinor/sidesheet';
 import { WorkflowStepAdminAtomApi } from '../../Atoms/workflowStepAdminAtomApi';
 import { useAdminContext } from '../../Hooks/useAdminContext';

--- a/src/packages/Admin/src/Components/Workspace/TableDropdownMenus.tsx
+++ b/src/packages/Admin/src/Components/Workspace/TableDropdownMenus.tsx
@@ -1,4 +1,4 @@
-import { Icon } from '@equinor/eds-core-react';
+import { Icon } from '@equinor/eds-core-react-old';
 import { tokens } from '@equinor/eds-tokens';
 import { MenuItem } from '@equinor/overlay-menu';
 import { Workflow, WorkflowStatus, WorkflowStepTemplate } from '@equinor/Workflow';

--- a/src/packages/Admin/src/Hooks/useWorkflowSidesheetEffects.tsx
+++ b/src/packages/Admin/src/Hooks/useWorkflowSidesheetEffects.tsx
@@ -1,4 +1,4 @@
-import { Icon } from '@equinor/eds-core-react';
+import { Icon } from '@equinor/eds-core-react-old';
 import { tokens } from '@equinor/eds-tokens';
 import { useEffect } from 'react';
 import { SidesheetApi } from '@equinor/sidesheet';

--- a/src/packages/Admin/src/Hooks/useWorkflowStepSidesheetEffects.tsx
+++ b/src/packages/Admin/src/Hooks/useWorkflowStepSidesheetEffects.tsx
@@ -1,4 +1,4 @@
-import { Icon } from '@equinor/eds-core-react';
+import { Icon } from '@equinor/eds-core-react-old';
 import { tokens } from '@equinor/eds-tokens';
 import { useEffect } from 'react';
 import { SidesheetApi } from '@equinor/sidesheet';

--- a/src/packages/Admin/styles/styles.ts
+++ b/src/packages/Admin/styles/styles.ts
@@ -1,4 +1,4 @@
-import { Button, Typography } from '@equinor/eds-core-react';
+import { Button, Typography } from '@equinor/eds-core-react-old';
 import { tokens } from '@equinor/eds-tokens';
 import styled from 'styled-components';
 

--- a/src/packages/BookmarksManager/src/components/BookmarksSidesheet/BookmarksSidesheet.tsx
+++ b/src/packages/BookmarksManager/src/components/BookmarksSidesheet/BookmarksSidesheet.tsx
@@ -1,4 +1,4 @@
-import { Button, CircularProgress, Icon, TextField, Typography } from '@equinor/eds-core-react';
+import { Button, CircularProgress, Icon, TextField, Typography } from '@equinor/eds-core-react-old';
 import { useRegistry } from '@equinor/lighthouse-portal-client';
 import { SidesheetApi } from '@equinor/sidesheet';
 import { ChangeEvent, useEffect, useState } from 'react';

--- a/src/packages/BookmarksManager/src/components/BookmarksSidesheet/MenuOptions.tsx
+++ b/src/packages/BookmarksManager/src/components/BookmarksSidesheet/MenuOptions.tsx
@@ -1,4 +1,4 @@
-import { Icon } from '@equinor/eds-core-react';
+import { Icon } from '@equinor/eds-core-react-old';
 import { Case, Switch } from '@equinor/JSX-Switch';
 import { useCurrentUser } from '@equinor/lighthouse-portal-client';
 import { IconMenu } from '@equinor/overlay-menu';

--- a/src/packages/BookmarksManager/src/components/BookmarksSidesheet/Modal/DeleteModalContent.tsx
+++ b/src/packages/BookmarksManager/src/components/BookmarksSidesheet/Modal/DeleteModalContent.tsx
@@ -1,4 +1,4 @@
-import { Button } from '@equinor/eds-core-react';
+import { Button } from '@equinor/eds-core-react-old';
 import { deleteBookmark as deleteBookmarkFunc, useBookmarkMutations } from '../../..';
 import { BookmarkResponse } from '../../../types';
 import { ButtonContainer } from './modal.styles';

--- a/src/packages/BookmarksManager/src/components/BookmarksSidesheet/Modal/EditModalContent.tsx
+++ b/src/packages/BookmarksManager/src/components/BookmarksSidesheet/Modal/EditModalContent.tsx
@@ -1,4 +1,4 @@
-import { Button, TextField } from '@equinor/eds-core-react';
+import { Button, TextField } from '@equinor/eds-core-react-old';
 import { useState } from 'react';
 import { patchBookmark } from '../../..';
 import { useBookmarkMutations } from '../../../hooks';

--- a/src/packages/BookmarksManager/src/components/BookmarksSidesheet/Modal/ShareModalContent.tsx
+++ b/src/packages/BookmarksManager/src/components/BookmarksSidesheet/Modal/ShareModalContent.tsx
@@ -1,4 +1,4 @@
-import { Button } from '@equinor/eds-core-react';
+import { Button } from '@equinor/eds-core-react-old';
 import styled from 'styled-components';
 import { BookmarkResponse } from '../../../types';
 import { ButtonContainer } from './modal.styles';

--- a/src/packages/BookmarksManager/src/components/BookmarksSidesheet/Modal/UnfavouriteModalContent.tsx
+++ b/src/packages/BookmarksManager/src/components/BookmarksSidesheet/Modal/UnfavouriteModalContent.tsx
@@ -1,4 +1,4 @@
-import { Button } from '@equinor/eds-core-react';
+import { Button } from '@equinor/eds-core-react-old';
 import { useBookmarkMutations } from '../../..';
 import { BookmarkResponse } from '../../../types';
 import { unFavouriteBookmark } from '../../../utils/api/unfavouriteBookmark';

--- a/src/packages/BookmarksManager/src/components/BookmarksSidesheet/Modal/UnshareModalContent.tsx
+++ b/src/packages/BookmarksManager/src/components/BookmarksSidesheet/Modal/UnshareModalContent.tsx
@@ -1,4 +1,4 @@
-import { Button } from '@equinor/eds-core-react';
+import { Button } from '@equinor/eds-core-react-old';
 import { patchBookmark } from '../../..';
 import { useBookmarkMutations } from '../../../hooks';
 import { BookmarkResponse } from '../../../types';

--- a/src/packages/CircuitDiagram/src/CircuitDiagram.tsx
+++ b/src/packages/CircuitDiagram/src/CircuitDiagram.tsx
@@ -24,7 +24,7 @@ import { Pipetest } from './types/pipetestTypes';
 import { NoCircuitDiagramFound } from './Components/NoCircuitDiagramFound';
 import { StatusCircle } from './Components/StatusCircle';
 import { useEffect, useMemo, useState } from 'react';
-import { Button } from '@equinor/eds-core-react';
+import { Button } from '@equinor/eds-core-react-old';
 
 export type CircuitDiagramTag = {
     tagNo: string;

--- a/src/packages/CircuitDiagram/src/Components/Cable.tsx
+++ b/src/packages/CircuitDiagram/src/Components/Cable.tsx
@@ -14,7 +14,7 @@ import { tokens } from '@equinor/eds-tokens';
 import { EleNetwork, EleNetworkCable } from '../types/eleNetwork';
 import { CheckListStatus } from '../types/pipetestTypes';
 import { StatusCircle } from './StatusCircle';
-import { Checkbox, Icon } from '@equinor/eds-core-react';
+import { Checkbox, Icon } from '@equinor/eds-core-react-old';
 import { Modal } from '@equinor/modal';
 import { memo, useState } from 'react';
 import { DisconnectModal } from './DisconnectModal';

--- a/src/packages/CircuitDiagram/src/Components/CircuitAndStarter.tsx
+++ b/src/packages/CircuitDiagram/src/Components/CircuitAndStarter.tsx
@@ -1,4 +1,4 @@
-import { Icon } from '@equinor/eds-core-react';
+import { Icon } from '@equinor/eds-core-react-old';
 import { tokens } from '@equinor/eds-tokens';
 import { Modal } from '@equinor/modal';
 import { memo, useState } from 'react';

--- a/src/packages/CircuitDiagram/src/Components/DisconnectModal.tsx
+++ b/src/packages/CircuitDiagram/src/Components/DisconnectModal.tsx
@@ -1,4 +1,4 @@
-import { Button, TextField } from '@equinor/eds-core-react';
+import { Button, TextField } from '@equinor/eds-core-react-old';
 import { KeyboardEventHandler } from 'react';
 import { ModalButtonContainer, ModalInputContainer } from '../../styles/styles';
 import { disconnectCable } from '../Api/disconnectCable';

--- a/src/packages/CircuitDiagram/src/Components/IsolateModal.tsx
+++ b/src/packages/CircuitDiagram/src/Components/IsolateModal.tsx
@@ -1,4 +1,4 @@
-import { Button, TextField } from '@equinor/eds-core-react';
+import { Button, TextField } from '@equinor/eds-core-react-old';
 import { KeyboardEventHandler } from 'react';
 import { ModalButtonContainer, ModalInputContainer } from '../../styles/styles';
 import { isolateCircuit } from '../Api/isolateCircuit';

--- a/src/packages/CircuitDiagram/styles/circuitStyles.ts
+++ b/src/packages/CircuitDiagram/styles/circuitStyles.ts
@@ -1,4 +1,4 @@
-import { Button } from '@equinor/eds-core-react';
+import { Button } from '@equinor/eds-core-react-old';
 import { tokens } from '@equinor/eds-tokens';
 import styled from 'styled-components';
 

--- a/src/packages/Components/Icon/ClickableIcon.tsx
+++ b/src/packages/Components/Icon/ClickableIcon.tsx
@@ -1,4 +1,4 @@
-import { Icon } from '@equinor/eds-core-react';
+import { Icon } from '@equinor/eds-core-react-old';
 import { tokens } from '@equinor/eds-tokens';
 
 export interface ClickableIconProps {
@@ -6,7 +6,7 @@ export interface ClickableIconProps {
     onClick?: React.MouseEventHandler<SVGSVGElement>;
     color?: string | undefined;
     size?: 16 | 24 | 32 | 40 | 48;
-    title?: string 
+    title?: string;
 }
 
 /**
@@ -20,13 +20,13 @@ export const ClickableIcon = ({
     onClick,
     color = `${tokens.colors.interactive.primary__resting.hex}`,
     size = 24,
-    title 
+    title,
 }: ClickableIconProps): JSX.Element => {
     return (
         <Icon
             size={size}
             name={name}
-            title={title} 
+            title={title}
             onClick={onClick}
             style={{ cursor: 'pointer' }}
             color={color}

--- a/src/packages/Components/Icon/Icon.tsx
+++ b/src/packages/Components/Icon/Icon.tsx
@@ -1,4 +1,4 @@
-import { Icon as EdsIcon } from '@equinor/eds-core-react';
+import { Icon as EdsIcon } from '@equinor/eds-core-react-old';
 import * as icons from '@equinor/eds-icons';
 
 EdsIcon.add({ ...icons });

--- a/src/packages/Filter/Components/FilterGroup/FilterGroup.tsx
+++ b/src/packages/Filter/Components/FilterGroup/FilterGroup.tsx
@@ -1,4 +1,4 @@
-import { Icon, Search } from '@equinor/eds-core-react';
+import { Icon, Search } from '@equinor/eds-core-react-old';
 import { Case, Switch } from '@equinor/JSX-Switch';
 import { useClickOutside } from '@equinor/lighthouse-utils';
 import React, { useCallback, useMemo, useRef, useState } from 'react';

--- a/src/packages/Filter/Components/FilterGroup/FilterGroupStyles.ts
+++ b/src/packages/Filter/Components/FilterGroup/FilterGroupStyles.ts
@@ -1,4 +1,4 @@
-import { Button, Checkbox } from '@equinor/eds-core-react';
+import { Button, Checkbox } from '@equinor/eds-core-react-old';
 import { tokens } from '@equinor/eds-tokens';
 import styled from 'styled-components';
 

--- a/src/packages/Filter/Components/FilterItem/FilterItem-Styles.ts
+++ b/src/packages/Filter/Components/FilterItem/FilterItem-Styles.ts
@@ -1,4 +1,4 @@
-import { Checkbox } from '@equinor/eds-core-react';
+import { Checkbox } from '@equinor/eds-core-react-old';
 import { tokens } from '@equinor/eds-tokens';
 import styled from 'styled-components';
 

--- a/src/packages/Filter/Components/FilterItem/FilterItem.tsx
+++ b/src/packages/Filter/Components/FilterItem/FilterItem.tsx
@@ -1,4 +1,4 @@
-import { Checkbox } from '@equinor/eds-core-react';
+import { Checkbox } from '@equinor/eds-core-react-old';
 import { memo, useMemo } from 'react';
 import { FilterGroup, ValueFormatterFunction } from '../../Hooks/useFilterApi';
 

--- a/src/packages/Filter/Components/FilterView/FilterView-style.ts
+++ b/src/packages/Filter/Components/FilterView/FilterView-style.ts
@@ -1,4 +1,4 @@
-import { Button } from '@equinor/eds-core-react';
+import { Button } from '@equinor/eds-core-react-old';
 import { tokens } from '@equinor/eds-tokens';
 import styled from 'styled-components';
 

--- a/src/packages/Filter/Components/Icon/Icon.tsx
+++ b/src/packages/Filter/Components/Icon/Icon.tsx
@@ -1,4 +1,4 @@
-import { Icon as EdsIcon } from '@equinor/eds-core-react';
+import { Icon as EdsIcon } from '@equinor/eds-core-react-old';
 import * as icons from '@equinor/eds-icons';
 
 EdsIcon.add({ ...icons });

--- a/src/packages/Form/src/Components/Date.tsx
+++ b/src/packages/Form/src/Components/Date.tsx
@@ -1,20 +1,16 @@
-import { MultiSelect as Select } from '@equinor/eds-core-react';
+import { MultiSelect as Select } from '@equinor/eds-core-react-old';
 
 import { Field } from '../Types/field';
 import styled from 'styled-components';
 import { tokens } from '@equinor/eds-tokens';
 import Icon from '../../../../components/Icon/Icon';
 
-
 interface DateProps<T> {
     field: Field<T>;
     editMode: boolean;
-
 }
 
-export function Date<T>({ field, editMode, }: DateProps<T>): JSX.Element {
-
-
+export function Date<T>({ field, editMode }: DateProps<T>): JSX.Element {
     if (typeof field.value === 'string' || typeof field.value === 'undefined') {
         return (
             <DateContainer>
@@ -31,7 +27,6 @@ export function Date<T>({ field, editMode, }: DateProps<T>): JSX.Element {
                             field.setValue(e.target.value as unknown as T);
                         }
                     }}
-
                 />
                 <Icon name="calendar_date_range" />
             </DateContainer>
@@ -54,16 +49,15 @@ const DateContainer = styled.div`
     }
 `;
 
-
 const DateInput = styled.input`
     width: 100%;
     font-family: Equinor;
-    font-size: 1.000rem;
+    font-size: 1rem;
     font-weight: 400;
-    line-height: 1.500em;
-    background:  ${tokens.colors.ui.background__light.rgba};
+    line-height: 1.5em;
+    background: ${tokens.colors.ui.background__light.rgba};
     border: none;
-    box-shadow: inset 0px -1px 0px 0px  ${tokens.colors.text.static_icons__tertiary.rgba};
+    box-shadow: inset 0px -1px 0px 0px ${tokens.colors.text.static_icons__tertiary.rgba};
     letter-spacing: 0.025em;
     text-align: left;
     padding-left: 8px;
@@ -71,17 +65,16 @@ const DateInput = styled.input`
     padding-bottom: 6px;
     color: ${tokens.colors.text.static_icons__tertiary.rgba};
     cursor: pointer;
-    :focus{
+    :focus {
         outline-offset: 0;
         box-shadow: none;
-        outline: 2px solid var(--eds_interactive_primary__resting,rgba(0,112,121,1));
+        outline: 2px solid var(--eds_interactive_primary__resting, rgba(0, 112, 121, 1));
         outline-offset: 0px;
     }
 
     ::-webkit-calendar-picker-indicator {
-        opacity:0;
-        margin-left:5px;
+        opacity: 0;
+        margin-left: 5px;
         cursor: pointer;
     }
-`
-
+`;

--- a/src/packages/Form/src/Components/MultiSelect.tsx
+++ b/src/packages/Form/src/Components/MultiSelect.tsx
@@ -1,4 +1,4 @@
-import { MultiSelect as Select } from '@equinor/eds-core-react';
+import { MultiSelect as Select } from '@equinor/eds-core-react-old';
 
 import { Field } from '../Types/field';
 import styled from 'styled-components';

--- a/src/packages/Form/src/Components/NumberInput.tsx
+++ b/src/packages/Form/src/Components/NumberInput.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Input } from '@equinor/eds-core-react';
+import { Input } from '@equinor/eds-core-react-old';
 import { Field } from '../Types/field';
 import styled from 'styled-components';
 

--- a/src/packages/Form/src/Components/SingleSelect.tsx
+++ b/src/packages/Form/src/Components/SingleSelect.tsx
@@ -1,6 +1,6 @@
 import React, { useEffect, useState } from 'react';
 
-import { SingleSelect as Select } from '@equinor/eds-core-react';
+import { SingleSelect as Select } from '@equinor/eds-core-react-old';
 import { Field } from '../Types/field';
 import styled from 'styled-components';
 

--- a/src/packages/Form/src/Components/TextArea.tsx
+++ b/src/packages/Form/src/Components/TextArea.tsx
@@ -1,4 +1,4 @@
-import { TextField } from '@equinor/eds-core-react';
+import { TextField } from '@equinor/eds-core-react-old';
 import { Field } from '../Types/field';
 
 interface TextAreaProps<T> {

--- a/src/packages/Form/src/Components/TextInput.tsx
+++ b/src/packages/Form/src/Components/TextInput.tsx
@@ -1,4 +1,4 @@
-import { TextField } from '@equinor/eds-core-react';
+import { TextField } from '@equinor/eds-core-react-old';
 import { Field } from '../Types/field';
 
 interface TextInputProps<T> {

--- a/src/packages/GardenUtils/src/components/popover/PopoverWrapper.tsx
+++ b/src/packages/GardenUtils/src/components/popover/PopoverWrapper.tsx
@@ -1,4 +1,4 @@
-import { Popover } from '@equinor/eds-core-react';
+import { Popover } from '@equinor/eds-core-react-old';
 import { MutableRefObject, PropsWithChildren, useLayoutEffect, useRef, useState } from 'react';
 import { createPortal } from 'react-dom';
 

--- a/src/packages/GardenUtils/src/components/sidesheet/SidesheetHeaderContent.tsx
+++ b/src/packages/GardenUtils/src/components/sidesheet/SidesheetHeaderContent.tsx
@@ -1,4 +1,4 @@
-import { Button, Icon } from '@equinor/eds-core-react';
+import { Button, Icon } from '@equinor/eds-core-react-old';
 import { tokens } from '@equinor/eds-tokens';
 import styled from 'styled-components';
 

--- a/src/packages/GardenUtils/src/components/sidesheet/TabTable.tsx
+++ b/src/packages/GardenUtils/src/components/sidesheet/TabTable.tsx
@@ -1,4 +1,4 @@
-import { Icon, Progress } from '@equinor/eds-core-react';
+import { Icon, Progress } from '@equinor/eds-core-react-old';
 import { tokens } from '@equinor/eds-tokens';
 import { Column, defaultGroupByFn, Table } from '@equinor/Table';
 import styled from 'styled-components';

--- a/src/packages/KPI/src/Components/KpiItem/KpiItem.tsx
+++ b/src/packages/KPI/src/Components/KpiItem/KpiItem.tsx
@@ -1,5 +1,5 @@
 import { tokens } from '@equinor/eds-tokens';
-import { Tooltip } from '@equinor/eds-core-react';
+import { Tooltip } from '@equinor/eds-core-react-old';
 import { useMemo } from 'react';
 import { Circle, StatusCard, Title, Value } from './KpiItemStyles';
 

--- a/src/packages/Modal/src/Components/Modal.tsx
+++ b/src/packages/Modal/src/Components/Modal.tsx
@@ -1,4 +1,4 @@
-import { Dialog, Scrim } from '@equinor/eds-core-react';
+import { Dialog, Scrim } from '@equinor/eds-core-react-old';
 import styled from 'styled-components';
 const DialogContainer = styled(Dialog)`
     width: 100%;

--- a/src/packages/ModelViewer/ModelViewer.tsx
+++ b/src/packages/ModelViewer/ModelViewer.tsx
@@ -1,5 +1,5 @@
 import { RendererConfiguration } from '@equinor/echo3dweb-viewer';
-import { Button, CircularProgress } from '@equinor/eds-core-react';
+import { Button, CircularProgress } from '@equinor/eds-core-react-old';
 import { tokens } from '@equinor/eds-tokens';
 import { Case, Switch } from '@equinor/JSX-Switch';
 import { Icon } from '@equinor/lighthouse-components';

--- a/src/packages/ModelViewer/components/selectionMenu.tsx
+++ b/src/packages/ModelViewer/components/selectionMenu.tsx
@@ -1,4 +1,4 @@
-import { Button } from '@equinor/eds-core-react';
+import { Button } from '@equinor/eds-core-react-old';
 import { tokens } from '@equinor/eds-tokens';
 import { Icon } from '@equinor/lighthouse-components';
 import { useModelViewerContext } from '../context/modelViewerContext';

--- a/src/packages/Sidesheet/Components/ResizableSidesheet.tsx
+++ b/src/packages/Sidesheet/Components/ResizableSidesheet.tsx
@@ -1,4 +1,4 @@
-import { Button } from '@equinor/eds-core-react';
+import { Button } from '@equinor/eds-core-react-old';
 import { tokens } from '@equinor/eds-tokens';
 import { ErrorBoundary, ErrorFallbackSidesheet } from '@equinor/ErrorBoundary';
 import { Icon } from '@equinor/lighthouse-components';

--- a/src/packages/Sidesheet/Components/SuspenseSidesheet.tsx
+++ b/src/packages/Sidesheet/Components/SuspenseSidesheet.tsx
@@ -1,4 +1,4 @@
-import { CircularProgress } from '@equinor/eds-core-react';
+import { CircularProgress } from '@equinor/eds-core-react-old';
 import { useIsMounted } from '@equinor/lighthouse-utils';
 import { useEffect, useState } from 'react';
 import styled from 'styled-components';

--- a/src/packages/StatusBar/src/Components/StatusItem/StatusItemStyles.ts
+++ b/src/packages/StatusBar/src/Components/StatusItem/StatusItemStyles.ts
@@ -1,4 +1,4 @@
-import { Card } from '@equinor/eds-core-react';
+import { Card } from '@equinor/eds-core-react-old';
 import { tokens } from '@equinor/eds-tokens';
 import styled from 'styled-components';
 

--- a/src/packages/Table/Components/Cell.tsx
+++ b/src/packages/Table/Components/Cell.tsx
@@ -1,4 +1,4 @@
-import { Checkbox } from '@equinor/eds-core-react';
+import { Checkbox } from '@equinor/eds-core-react-old';
 import { Hooks } from 'react-table';
 import styled from 'styled-components';
 import { TableData } from '../Types/types';

--- a/src/packages/Table/Components/Cells/LinkCell.tsx
+++ b/src/packages/Table/Components/Cells/LinkCell.tsx
@@ -1,7 +1,7 @@
 import React, { HTMLAttributes, useCallback } from 'react';
 import { CellProps } from 'react-table';
 import { CellRenderProps, TableData } from '../../Types/types';
-import { Icon } from '@equinor/eds-core-react';
+import { Icon } from '@equinor/eds-core-react-old';
 import styled from 'styled-components';
 import { tokens } from '@equinor/eds-tokens';
 const LinkCell = <T extends TableData>(props: CellProps<T, CellRenderProps<T>>) => {

--- a/src/packages/Table/Components/ColumnPicker/ColumnPicker.tsx
+++ b/src/packages/Table/Components/ColumnPicker/ColumnPicker.tsx
@@ -1,6 +1,6 @@
 import { useState } from 'react';
 import { ReactSortable } from 'react-sortablejs';
-import { Checkbox, Icon } from '@equinor/eds-core-react';
+import { Checkbox, Icon } from '@equinor/eds-core-react-old';
 import { TableAPI, TableData } from '@equinor/Table';
 import { ColumnInstance } from 'react-table';
 

--- a/src/packages/Table/Components/ExportToExcel/ExportToExcel.tsx
+++ b/src/packages/Table/Components/ExportToExcel/ExportToExcel.tsx
@@ -1,4 +1,4 @@
-import { Progress } from '@equinor/eds-core-react';
+import { Progress } from '@equinor/eds-core-react-old';
 import { useMutation } from 'react-query';
 import { Row } from 'react-table';
 import { StyledButton } from './exportToExcel.styles';

--- a/src/packages/Table/Components/ExportToExcel/exportToExcel.styles.ts
+++ b/src/packages/Table/Components/ExportToExcel/exportToExcel.styles.ts
@@ -1,4 +1,4 @@
-import { Button } from '@equinor/eds-core-react';
+import { Button } from '@equinor/eds-core-react-old';
 import styled from 'styled-components';
 
 export const StyledButton = styled(Button)<{ width?: string }>`

--- a/src/packages/Table/Components/GoupedCell.tsx
+++ b/src/packages/Table/Components/GoupedCell.tsx
@@ -1,4 +1,4 @@
-import { Icon } from '@equinor/eds-core-react';
+import { Icon } from '@equinor/eds-core-react-old';
 import { tokens } from '@equinor/eds-tokens';
 import styled from 'styled-components';
 

--- a/src/packages/Table/Components/HeaderCell.tsx
+++ b/src/packages/Table/Components/HeaderCell.tsx
@@ -1,4 +1,4 @@
-import { Icon } from '@equinor/eds-core-react';
+import { Icon } from '@equinor/eds-core-react-old';
 import { useRef, useState } from 'react';
 import { HeaderGroup } from 'react-table';
 import { TableData } from '../Types/types';

--- a/src/packages/Table/Components/HeaderCellMenu.tsx
+++ b/src/packages/Table/Components/HeaderCellMenu.tsx
@@ -1,4 +1,4 @@
-import { Menu, Typography } from '@equinor/eds-core-react';
+import { Menu, Typography } from '@equinor/eds-core-react-old';
 import { HeaderCellProps } from './HeaderCell';
 
 interface HeaderCellMenuProps extends HeaderCellProps {

--- a/src/packages/Workflow/src/Components/AdvancedDocumentSearch/AdvancedDocumentSearch.tsx
+++ b/src/packages/Workflow/src/Components/AdvancedDocumentSearch/AdvancedDocumentSearch.tsx
@@ -1,5 +1,5 @@
 import { Fragment, useState } from 'react';
-import { Button, Icon, Progress, Scrim, TextField } from '@equinor/eds-core-react';
+import { Button, Icon, Progress, Scrim, TextField } from '@equinor/eds-core-react-old';
 import { Case, Switch } from '@equinor/JSX-Switch';
 import { tokens } from '@equinor/eds-tokens';
 

--- a/src/packages/Workflow/src/Components/AdvancedDocumentSearch/BatchCheckbox.tsx
+++ b/src/packages/Workflow/src/Components/AdvancedDocumentSearch/BatchCheckbox.tsx
@@ -1,4 +1,4 @@
-import { Checkbox, Tooltip } from '@equinor/eds-core-react';
+import { Checkbox, Tooltip } from '@equinor/eds-core-react-old';
 import styled from 'styled-components';
 
 interface BatchCheckboxesProps {

--- a/src/packages/Workflow/src/Components/AdvancedDocumentSearch/Results.tsx
+++ b/src/packages/Workflow/src/Components/AdvancedDocumentSearch/Results.tsx
@@ -1,4 +1,4 @@
-import { Checkbox } from '@equinor/eds-core-react';
+import { Checkbox } from '@equinor/eds-core-react-old';
 import { ResultLabel, ResultItem } from './advancedSearch.styles';
 import { useState } from 'react';
 import { TypedSelectOption } from '../PersonRoleSearch/typedSelectOption';

--- a/src/packages/Workflow/src/Components/Inputs/SearchableDropdown/applyEds.tsx
+++ b/src/packages/Workflow/src/Components/Inputs/SearchableDropdown/applyEds.tsx
@@ -1,4 +1,4 @@
-import { Button, Icon, Progress } from '@equinor/eds-core-react';
+import { Button, Icon, Progress } from '@equinor/eds-core-react-old';
 import { tokens } from '@equinor/eds-tokens';
 import { components, Theme } from 'react-select';
 import styled from 'styled-components';

--- a/src/packages/Workflow/src/Components/Modal/SignWithCommentModal.tsx
+++ b/src/packages/Workflow/src/Components/Modal/SignWithCommentModal.tsx
@@ -1,4 +1,4 @@
-import { Button, TextField } from '@equinor/eds-core-react';
+import { Button, TextField } from '@equinor/eds-core-react-old';
 import {
     ButtonContainer,
     CriteriaSignState,

--- a/src/packages/Workflow/src/Components/PersonRoleSearch/applyEds.tsx
+++ b/src/packages/Workflow/src/Components/PersonRoleSearch/applyEds.tsx
@@ -1,4 +1,4 @@
-import { Button, Icon, Progress } from '@equinor/eds-core-react';
+import { Button, Icon, Progress } from '@equinor/eds-core-react-old';
 import { tokens } from '@equinor/eds-tokens';
 import { components, Theme } from 'react-select';
 import styled from 'styled-components';

--- a/src/packages/Workflow/src/Components/SearchReferences/getReferenceIcon.tsx
+++ b/src/packages/Workflow/src/Components/SearchReferences/getReferenceIcon.tsx
@@ -1,4 +1,4 @@
-import { Icon } from '@equinor/eds-core-react';
+import { Icon } from '@equinor/eds-core-react-old';
 import { tokens } from '@equinor/eds-tokens';
 import { ReferenceType } from '@equinor/Workflow';
 import { CommPkgIcon } from '../WorkflowIcons/CommPkgIcon';

--- a/src/packages/Workflow/src/Components/Workflow/SelectWorkflowTemplate.tsx
+++ b/src/packages/Workflow/src/Components/Workflow/SelectWorkflowTemplate.tsx
@@ -1,5 +1,5 @@
 import { QueryKey, useQuery, UseQueryOptions } from 'react-query';
-import { SingleSelect } from '@equinor/eds-core-react';
+import { SingleSelect } from '@equinor/eds-core-react-old';
 import { Workflow, WorkflowTemplate } from '../../Types/WorkflowTypes';
 import { useState } from 'react';
 

--- a/src/packages/Workflow/src/Components/Workflow/WorkflowCompact.tsx
+++ b/src/packages/Workflow/src/Components/Workflow/WorkflowCompact.tsx
@@ -1,4 +1,4 @@
-import { Icon } from '@equinor/eds-core-react';
+import { Icon } from '@equinor/eds-core-react-old';
 import { tokens } from '@equinor/eds-tokens';
 import { useRef, useState } from 'react';
 import styled from 'styled-components';

--- a/src/packages/Workflow/src/Components/Workflow/WorkflowEditorHelpers.tsx
+++ b/src/packages/Workflow/src/Components/Workflow/WorkflowEditorHelpers.tsx
@@ -1,4 +1,4 @@
-import { Icon } from '@equinor/eds-core-react';
+import { Icon } from '@equinor/eds-core-react-old';
 import { WorkflowStepTemplate, Criteria, CriteriaStatus } from '@equinor/Workflow';
 
 import { InsertAfter } from './InsertAfter';

--- a/src/packages/Workflow/src/Components/Workflow/WorkflowStepRender.tsx
+++ b/src/packages/Workflow/src/Components/Workflow/WorkflowStepRender.tsx
@@ -1,4 +1,4 @@
-import { SingleSelect } from '@equinor/eds-core-react';
+import { SingleSelect } from '@equinor/eds-core-react-old';
 import { ClickableIcon } from '@equinor/lighthouse-components';
 import { IconMenu } from '@equinor/overlay-menu';
 import {

--- a/src/packages/Workflow/styles/workflow.styles.ts
+++ b/src/packages/Workflow/styles/workflow.styles.ts
@@ -1,6 +1,6 @@
 import { tokens } from '@equinor/eds-tokens';
 import styled from 'styled-components';
-import { Button, SingleSelect } from '@equinor/eds-core-react';
+import { Button, SingleSelect } from '@equinor/eds-core-react-old';
 
 export const DraggableIconWrapper = styled.div`
     cursor: grab;


### PR DESCRIPTION
EDS has breaking changes from 0.14.2 to 0.36.0. Its a huge job to fix all of this in one pr. Using pnpm alias we are installing both packages so we can incrementally remove the old version of EDS.


To import the old version 
```TS
import { } from '@equinor/eds-core-react-old
```


To import the new version 
```TS
import { } from '@equinor/eds-core-react
```


It sucks that the diff is so large but I think its the best way because we want people to use the new version and not the old