### PR TITLE
fix: state clears when sidesheet is minimized

### DIFF
--- a/src/packages/Sidesheet/Components/ResizableSidesheet.tsx
+++ b/src/packages/Sidesheet/Components/ResizableSidesheet.tsx
@@ -52,9 +52,9 @@ export const ResizableSidesheet = (): JSX.Element | null => {
   if (!SidesheetComponent) return null;
 
   return (
-    <div style={{ height: '100%', width: isMinimized ? "24px" : "100%" }}>
+    <div style={{ height: '100%' }}>
       <Resizable
-        size={{ width: width, height: '100%' }}
+        size={{ width: isMinimized ? "24px" : width, height: '100%' }}
         maxWidth={'100vw'}
         onResizeStop={(e, direction, ref, d) => {
           if (width + d.width < minWidth) {
@@ -62,23 +62,26 @@ export const ResizableSidesheet = (): JSX.Element | null => {
             setIsMinimized(true);
           } else {
             setWidth(width + d.width);
+            setIsMinimized(false);
           }
         }}
       >
         <Header>
           <LeftHeader>
             <ColourTab appColor={color} onClick={handleMinimize}>
-              <Icon name="chevron_right" size={24} color={'white'} />
+              <Icon name={isMinimized ? "chevron_left" : "chevron_right"} size={24} color={'white'} />
             </ColourTab>
             <Title>{title}</Title>
           </LeftHeader>
+          {!isMinimized && (
+            <RightHeader>
+              {menuItems.length > 0 && <IconMenu placement="bottom" items={menuItems} />}
+              <Button variant="ghost_icon" onClick={closeSidesheet}>
+                <Icon name="close" size={24} color={tokens.colors.interactive.primary__resting.hex} />
+              </Button>
+            </RightHeader>
+          )}
 
-          <RightHeader>
-            {menuItems.length > 0 && <IconMenu placement="bottom" items={menuItems} />}
-            <Button variant="ghost_icon" onClick={closeSidesheet}>
-              <Icon name="close" size={24} color={tokens.colors.interactive.primary__resting.hex} />
-            </Button>
-          </RightHeader>
         </Header>
 
         <ErrorBoundary FallbackComponent={ErrorFallbackSidesheet} routeName={'Sidesheet'}>

--- a/src/packages/Sidesheet/Components/ResizableSidesheet.tsx
+++ b/src/packages/Sidesheet/Components/ResizableSidesheet.tsx
@@ -51,23 +51,8 @@ export const ResizableSidesheet = (): JSX.Element | null => {
 
   if (!SidesheetComponent) return null;
 
-  if (isMinimized) {
-    return (
-      //HACK: auto doesnt work?
-      <div style={{ width: '24px' }}>
-        <ColourTab appColor={color} onClick={handleMinimize}>
-          <Icon name="chevron_left" color={'white'} />
-        </ColourTab>
-        <RotatedText>{title}</RotatedText>
-        <div style={{ display: 'none' }}>
-          <SidesheetComponent {...sidesheetProps} />
-        </div>
-      </div>
-    );
-  }
-
   return (
-    <div style={{ height: '100%' }}>
+    <div style={{ height: '100%', width: isMinimized ? "24px" : "100%" }}>
       <Resizable
         size={{ width: width, height: '100%' }}
         maxWidth={'100vw'}
@@ -97,10 +82,11 @@ export const ResizableSidesheet = (): JSX.Element | null => {
         </Header>
 
         <ErrorBoundary FallbackComponent={ErrorFallbackSidesheet} routeName={'Sidesheet'}>
-          <div style={{ height: '95%' }}>
+          <div style={{ height: '95%', display: isMinimized ? "none" : "block" }}>
             <SidesheetComponent {...sidesheetProps} />
           </div>
         </ErrorBoundary>
+        {isMinimized && <RotatedText>{title}</RotatedText>}
       </Resizable>
     </div>
   );


### PR DESCRIPTION
Kinda hacky solution but if you render a different tree for when its minimized the children will lose its internal state. A caching solution was considered but the bug potential is too high

Impact: The code changed is used by all applications in the portal

Fixes: #1592