### PR TITLE
fix: release control temporariliy fix punch search by reverting to v1 search

### DIFF
--- a/src/packages/Workflow/src/Api/FAM/searchPunchListItems.ts
+++ b/src/packages/Workflow/src/Api/FAM/searchPunchListItems.ts
@@ -1,11 +1,17 @@
 import { httpClient } from '@equinor/lighthouse-portal-client';
+import { generateExpressions, generateFamRequest } from '../../../../FamRequestBuilder/src';
 import { PunchListItem } from '../../Types/FAMTypes';
 import { throwOnError } from '../throwOnError';
 
 const columnNames: string[] = ['PunchItemNo', 'Description'];
 const facility = 'JCA';
 const view = 'Completion.CompletionPunchItem_v1';
-export async function searchPunchListItems(
+
+
+/**
+* Keeping double implementation for a while since FAM is experiencing issues from time to time. V2 is the preffered view to avoid stale data. 
+*/
+export async function searchPunchListItemsV2(
   id: string,
   signal?: AbortSignal
 ): Promise<PunchListItem[]> {
@@ -37,4 +43,37 @@ ORDER BY facility asc`,
   }
 
   return punchListItems.data;
+}
+
+export async function searchPunchListItemsV1(
+    id: string,
+    signal?: AbortSignal
+): Promise<PunchListItem[]> {
+    const { FAM } = httpClient();
+
+    const columnNames: string[] = ['PunchItemNo', 'Description'];
+
+    const expressions = generateExpressions('PunchItemNo', 'Like', [id]);
+
+    const requestArgs = generateFamRequest(columnNames, 'Or', expressions, { take: 50, skip: 0 });
+
+    const res = await FAM.fetch(
+        'v1/typed/completion/completionPunchItem/facility/JCA?view-version=v1',
+        {
+            method: 'POST',
+            headers: { ['content-type']: 'application/json' },
+            body: JSON.stringify(requestArgs),
+            signal,
+        }
+    );
+
+    await throwOnError(res, 'Failed to get punch list items');
+
+    const punchListItems: PunchListItem[] = await res.json();
+
+    if (!Array.isArray(punchListItems)) {
+        throw 'Invalid response';
+    }
+
+    return punchListItems;
 }

--- a/src/packages/Workflow/src/Hooks/Search/useCompletionSearch.ts
+++ b/src/packages/Workflow/src/Hooks/Search/useCompletionSearch.ts
@@ -1,7 +1,7 @@
 import { FamTag, FAMTypes, TypedSelectOption } from '@equinor/Workflow';
 import { searchHtCable } from '../../Api/FAM/searchHtCable';
 import { searchHtCableTagNo } from '../../Api/FAM/searchHtCableTagNo';
-import { searchPunchListItems } from '../../Api/FAM/searchPunchListItems';
+import { searchPunchListItemsV1 } from '../../Api/FAM/searchPunchListItems';
 import { searchTag } from '../../Api/FAM/searchTag';
 import { searchTagNo } from '../../Api/FAM/searchTagNo';
 import { getScopeTag } from '../../Api/Backend/getScopeTag';
@@ -37,7 +37,7 @@ export function useCompletionSearch(): FAMSearch {
         ];
       }
       case 'punch': {
-        const items = await searchPunchListItems(searchValue, signal);
+        const items = await searchPunchListItemsV1(searchValue, signal);
         return items.map(
           ({ description, punchItemNo }): TypedSelectOption => ({
             label: `${punchItemNo} - ${description}`,


### PR DESCRIPTION
FAM's V2 endpoint is not working atm (internal server error). This is a temporary fix that will enable the punch search to work while they resolve the issue