### PR TITLE
feat: :sparkles: update views to the newest version

### DIFF
--- a/src/apps/Loop/index.tsx
+++ b/src/apps/Loop/index.tsx
@@ -10,12 +10,15 @@ import {
 
 async function responseAsync(signal?: AbortSignal | undefined): Promise<Response> {
   const { FAM } = httpClient();
-  return await FAM.fetchAsync('v1/typed/Completion/Custom_LoopMCCR/facility/JCA?view-version=v1', {
-    method: 'POST',
-    headers: { 'content-type': 'application/json' },
-    body: JSON.stringify({}),
-    signal,
-  });
+  return await FAM.fetchAsync(
+    'v1/typed/Completion/Custom_LoopMCCRv1/facility/JCA?view-version=v1',
+    {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({}),
+      signal,
+    }
+  );
 }
 
 export function setup(addApi: ClientApi): void {

--- a/src/apps/Loop/utility/api/getChecklistsForLoop.ts
+++ b/src/apps/Loop/utility/api/getChecklistsForLoop.ts
@@ -20,7 +20,7 @@ export const checklistColumnNames = [
 export const getChecklistsForLoop = async (famFilter: FamRequest, signal?: AbortSignal) => {
   const { FAM } = httpClient();
   const res = await FAM.fetchAsync(
-    `v1/typed/completion/custom_loopsidesheetchecklists/facility/JCA?view-version=v1`,
+    `v1/typed/completion/custom_loopsidesheetchecklistsv1/facility/JCA?view-version=v1`,
     {
       method: 'POST',
       headers: { 'content-type': 'application/json' },

--- a/src/apps/Loop/utility/api/getLoopContent.ts
+++ b/src/apps/Loop/utility/api/getLoopContent.ts
@@ -20,7 +20,7 @@ export const getLoopContent = async (
 ): Promise<LoopContent[]> => {
   const { FAM } = httpClient();
   const res = await FAM.fetchAsync(
-    `v1/typed/completion/custom_loopcontent/facility/JCA?view-version=v1`,
+    `v1/typed/completion/custom_loopcontentv1/facility/JCA?view-version=v1`,
     {
       method: 'POST',
       headers: { 'content-type': 'application/json' },

--- a/src/apps/Loop/utility/api/getWorkorders.ts
+++ b/src/apps/Loop/utility/api/getWorkorders.ts
@@ -30,7 +30,7 @@ export const getWorkorders = async (
 ): Promise<Workorder[]> => {
   const { FAM } = httpClient();
   const res = await FAM.fetchAsync(
-    `v1/typed/completion/custom_loopworkorders/facility/JCA?view-version=v1`,
+    `v1/typed/completion/custom_loopworkordersv1/facility/JCA?view-version=v1`,
     {
       method: 'POST',
       headers: { 'content-type': 'application/json' },

--- a/src/apps/Loop/utility/config/sidesheetConfig.ts
+++ b/src/apps/Loop/utility/config/sidesheetConfig.ts
@@ -11,7 +11,7 @@ const idResolverFunction = async (id: string): Promise<Loop> => {
   const expressions = generateExpressions('checklistUrlId', 'Equals', [id]);
   const requestArgs = generateFamRequest(customLoopMccrColumns, 'Or', expressions);
   const res = await FAM.fetchAsync(
-    'v1/typed/Completion/Custom_LoopMCCR/facility/JCA?view-version=v1',
+    'v1/typed/Completion/Custom_LoopMCCRv1/facility/JCA?view-version=v1',
     {
       body: JSON.stringify(requestArgs),
       method: 'POST',

--- a/src/packages/FamRequestBuilder/Readme.md
+++ b/src/packages/FamRequestBuilder/Readme.md
@@ -24,7 +24,7 @@ const { data, isLoading, error } = useQuery(['checklists', checklistId], ({ sign
 
 export const getChecklistsForLoop = async (famFilter: FamRequest, signal?: AbortSignal) => {
   const { FAM } = httpClient();
-  const res = await FAM.post(`v0.1/dynamic/completion/custom_loopsidesheetchecklists/JCA`, {
+  const res = await FAM.post(`v0.1/dynamic/completion/custom_loopsidesheetchecklistsv1/JCA`, {
     body: JSON.stringify(famFilter),
     signal,
   });


### PR DESCRIPTION
### Short summary
Update views (only found loop views) to the newest version.

Custom_LoopContent -> Custom_LoopContentv1
Custom_LoopMCCR -> Custom_LoopMCCRv1
Custom_LoopSidesheetChecklists -> Custom_LoopSidesheetChecklistsv1
Custom_LoopWorkOrders -> Custom_LoopWorkOrdersv1

All the views had exactly the same attributes. I didn't check all the types, but it seems like everything works as expected.

Link to issue: https://github.com/equinor/lighthouse/issues/601

### PR Checklist

- [x] I have performed a self-review of my own code
- [x] I have written a short summary of my changes in the PR
- [x] I have linked related issue to the PR

> [!TIP]
> To deploy the PR to Dev/Dev2, use the [Deploy PR to dev🚀](https://github.com/equinor/lighthouse-client/actions/workflows/deploy-pr.yml) action.
> Remember to deploy any backend changes to Dev/Dev2 as well!

> [!CAUTION]
> ⛔ I understand by merging my PR, the changes will be deployed to production immediately ⛔
