### PR TITLE
fix: Ignore SM if >

### DIFF
--- a/.github/workflows/post-service-message.yml
+++ b/.github/workflows/post-service-message.yml
@@ -12,7 +12,7 @@ on:
           - dev2
           - prod
       message:
-        description: "The service message, leave empty to delete current SM"
+        description: "The service message, leave > to delete current SM"
         default: ">"
         required: false
         type: string

--- a/.github/workflows/post-service-message.yml
+++ b/.github/workflows/post-service-message.yml
@@ -13,6 +13,7 @@ on:
           - prod
       message:
         description: "The service message, leave empty to delete current SM"
+        default: ">"
         required: false
         type: string
 

--- a/src/components/Messages/Service/Hooks/useServiceMessage.ts
+++ b/src/components/Messages/Service/Hooks/useServiceMessage.ts
@@ -33,7 +33,7 @@ export function useServiceMessage(): Return {
 
   useEffect(() => {
     const stringifiedServiceMessage = window.SERVICE_MESSAGE;
-    if (!stringifiedServiceMessage || stringifiedServiceMessage.length == 0) return;
+    if (!stringifiedServiceMessage || stringifiedServiceMessage == ">" || stringifiedServiceMessage.length == 0) return;
     try {
       const message = stringifiedServiceMessage;
       if (message.length == 0) {


### PR DESCRIPTION
Radix has a limitation which is you cannot send an empty value using the rx cli. This makes it impossible to clear service messages from a github action. You can still do it in GUI. Added code to treat SM as empty if == ">"
