### PR TITLE
Migrate to Fusion app mangement v2 api

### DIFF
--- a/src/AppClient.tsx
+++ b/src/AppClient.tsx
@@ -144,11 +144,13 @@ const useSetupClients = () => {
   const fusionPeople = useHttpClient('fusionPeople');
   const fusionTasks = useHttpClient('fusionTasks');
   const procosys = useHttpClient('procosys');
+  const fusionApps = useHttpClient('fusionApps');
 
   useEffect(() => {
     registerClients({
       echoHierarchy,
       echoModelDist,
+      fusionApps,
       FAM,
       fusion,
       fusionBookmarks,

--- a/src/Core/Client/Types/ScopeAndUrls.ts
+++ b/src/Core/Client/Types/ScopeAndUrls.ts
@@ -1,5 +1,6 @@
 export interface Scope {
   fusion: string;
+  fusionApps: string;
   procosys: string;
   echoModelDist: string;
   echoHierarchy: string;
@@ -18,6 +19,7 @@ export interface Urls {
   echoModelDist: string;
   echoHierarchy: string;
   fusion: string;
+  fusionApps: string;
   procosys: string;
   scopeChange: string;
   FAM: string;


### PR DESCRIPTION
Following the release of app management v2 api we need to migrate to the new api 

Code chunking has not been handled at this point, not sure how we should solve this. Before we enable chunking we have to solve this.

TODO: Update env variables in production before merging

Issue:
- #1858

Migration guide supplied by fusion 
- equinor/fusion-rfcs#70